### PR TITLE
Fix body text parsing

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -131,8 +131,10 @@ class Email(object):
         :rtype:             bool
         """
         body_keys = self.body_parts.keys()
-        if ('plain' in body_keys) or ('html' in body_keys):
-            raise AttributeError('This email already has a body!')
+        if body_plain and ('plain' in body_keys):
+            raise AttributeError('This email already has a plain body!')
+        if body_html and ('html' in body_keys):
+            raise AttributeError('This email already has an HTML body!')
             # TODO: create a new "local" email to replace the SELF with new body
         if not (body_html or body_plain):
             raise ValueError('No HTML or TEXT provided')

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -139,8 +139,8 @@ class Email(object):
             raise ValueError('No HTML or TEXT provided')
         body_plain = body_plain or html2text(body_html)
         body_html = body_html or body_plain
-        msg_plain = MIMEText(body_plain, _subtype='plain')
-        msg_html = MIMEText(body_html, _subtype='html')
+        msg_plain = MIMEText(body_plain, _subtype='plain', _charset='utf-8')
+        msg_html = MIMEText(body_html, _subtype='html', _charset='utf-8')
         msg_part = MIMEMultipart(_subtype='alternative')
         msg_part.attach(msg_plain)
         msg_part.attach(msg_html)

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -68,7 +68,6 @@ class Email(object):
             self.email['Subject'] = subject
         from_address = kwargs.get('from', False)
         if from_address:
-        
             self.email['From'] = from_address
         cc_address = kwargs.get('cc', False)
         if cc_address:
@@ -128,7 +127,7 @@ class Email(object):
         :type body_plain:   str
         :param body_html:   HTML Text for the Body
         :type body_html:    str
-        :return:            True if updated, Raises an exception if failed. 
+        :return:            True if updated, Raises an exception if failed.
         :rtype:             bool
         """
         body_keys = self.body_parts.keys()
@@ -138,12 +137,12 @@ class Email(object):
         if not (body_html or body_plain):
             raise ValueError('No HTML or TEXT provided')
         body_plain = body_plain or html2text(body_html)
-        body_html = body_html or body_plain
         msg_plain = MIMEText(body_plain, _subtype='plain', _charset='utf-8')
-        msg_html = MIMEText(body_html, _subtype='html', _charset='utf-8')
         msg_part = MIMEMultipart(_subtype='alternative')
         msg_part.attach(msg_plain)
-        msg_part.attach(msg_html)
+        if body_html:
+            msg_html = MIMEText(body_html, _subtype='html', _charset='utf-8')
+            msg_part.attach(msg_html)
         self.email.attach(msg_part)
         return True
 

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -131,9 +131,9 @@ with description("Creating an Email"):
             e = Email()
             plain = 'Text-based body for the e-mail'
             e.add_body_text(body_plain=plain)
-            expect(e.body_parts).to(have_keys('plain', 'html'))
+            expect(e.body_parts).to(have_key('plain'))
+            expect(e.body_parts).to_not(have_key('html'))
             expect(e.body_parts['plain']).to(equal(plain))
-            expect(e.body_parts['html']).to(equal(plain))
 
         with it("must add body to Email with only html text"):
             e = Email()
@@ -284,13 +284,6 @@ with description("Creating an Email"):
             expect(e.body_parts['plain']).to(equal(self.vals['body_text']))
             expect(e.body_parts['html']).to(equal(self.vals['body_html']))
 
-        with it('must parse text2html if no html provided'):
-            vals = self.vals.copy()
-            vals.pop('body_html')
-            e = Email(**vals)
-            expect(e.body_parts).to(have_keys('plain', 'html'))
-            expect(e.body_parts['html']).to(equal(vals['body_text']))
-
         with it('must parse html2text if no text provided'):
             vals = self.vals.copy()
             vals.pop('body_text')
@@ -298,7 +291,7 @@ with description("Creating an Email"):
             e = Email(**vals)
             expect(e.body_parts).to(have_keys('plain', 'html'))
             expect(e.body_parts['plain']).to(equal(body_text))
-        
+
         with it('must return the email as MIME-formated string'):
             e = Email(**self.vals)
             expect(

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -148,10 +148,27 @@ with description("Creating an Email"):
             e = Email()
             expect(e.add_body_text).to(raise_error(ValueError))
 
-        with it('must raise AtributeErrpr if adding the body a 2nd time'):
+        with it('must be able to add plain and html to the body separately'):
             e = Email()
-            e.add_body_text('some_body_text')
-            expect(e.add_body_text).to(raise_error(AttributeError))
+            html = 'Html-based body for the e-mail'
+            plain = html2text(html)
+            e.add_body_text(body_plain=plain)
+            e.add_body_text(body_html=html)
+            expect(e.body_parts).to(have_keys('plain', 'html'))
+            expect(e.body_parts['plain']).to(equal(plain))
+            expect(e.body_parts['html']).to(equal(html))
+
+        with it('must raise AtributeErrpr if adding the body a 2nd time'):
+            def call_wrongly_plain():
+                e = Email()
+                e.add_body_text(body_plain='some_body_text')
+                e.add_body_text(body_plain='some_body_text')
+            def call_wrongly_html():
+                e = Email()
+                e.add_body_text(body_html='some_body_text')
+                e.add_body_text(body_html='some_body_text')
+            expect(call_wrongly_plain).to(raise_error(AttributeError))
+            expect(call_wrongly_html).to(raise_error(AttributeError))
 
         with it('must add an attachments to body'):
             import base64


### PR DESCRIPTION
1. Fix body_text charset of MIMEText
2. Fix body_text_html setting
  - If not provided html, don't set with the plain text
  - If only plain is set, be able to set html
3. Remove checks of setting html if adding only plain text