### PR TITLE
Update HEADER adding to email Object

### DIFF
--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -306,14 +306,14 @@ with description("Creating an Email"):
             expect(e.body_parts['html']).to(equal(self.vals['body_html']))
 
         with it('must add addresses correctly as "name" <address>'):
-            address = 'spécial <special@example.com'
-            expected_address = [','.join(['"spécial" <special@example.com>'])]
+            address = 'spécial <special@example.com>'
             e = Email(to=address)
-            expect(e.to).to(equal(expected_address))
+            expect(e.to).to(equal([address]))
             e = Email(cc=address)
-            expect(e.cc).to(equal(expected_address))
+            expect(e.cc).to(equal([address]))
             e = Email(bcc=address)
-            expect(e.bcc).to(equal(expected_address))
+            expect(e.bcc).to(equal([address]))
+            print(e.mime_string)
 
         with it('must parse html2text if no text provided'):
             vals = self.vals.copy()

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -305,6 +305,20 @@ with description("Creating an Email"):
             expect(e.body_parts['plain']).to(equal(self.vals['body_text']))
             expect(e.body_parts['html']).to(equal(self.vals['body_html']))
 
+        with it('must add addresses correctly as "name" <address>'):
+            addresses = [
+                'test <testing@example.com>',
+                'spécial <special@example.com'
+            ]
+            expected_address = [','.join(['test <testing@example.com>',
+                 '"spécial" <special@example.com>'])]
+            e = Email(to=addresses)
+            expect(e.to).to(equal(expected_address))
+            e = Email(cc=addresses)
+            expect(e.cc).to(equal(expected_address))
+            e = Email(bcc=addresses)
+            expect(e.bcc).to(equal(expected_address))
+
         with it('must parse html2text if no text provided'):
             vals = self.vals.copy()
             vals.pop('body_text')

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -306,17 +306,13 @@ with description("Creating an Email"):
             expect(e.body_parts['html']).to(equal(self.vals['body_html']))
 
         with it('must add addresses correctly as "name" <address>'):
-            addresses = [
-                'test <testing@example.com>',
-                'spécial <special@example.com'
-            ]
-            expected_address = [','.join(['test <testing@example.com>',
-                 '"spécial" <special@example.com>'])]
-            e = Email(to=addresses)
+            address = 'spécial <special@example.com'
+            expected_address = [','.join(['"spécial" <special@example.com>'])]
+            e = Email(to=address)
             expect(e.to).to(equal(expected_address))
-            e = Email(cc=addresses)
+            e = Email(cc=address)
             expect(e.cc).to(equal(expected_address))
-            e = Email(bcc=addresses)
+            e = Email(bcc=address)
             expect(e.bcc).to(equal(expected_address))
 
         with it('must parse html2text if no text provided'):

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -313,7 +313,6 @@ with description("Creating an Email"):
             expect(e.cc).to(equal([address]))
             e = Email(bcc=address)
             expect(e.bcc).to(equal([address]))
-            print(e.mime_string)
 
         with it('must parse html2text if no text provided'):
             vals = self.vals.copy()


### PR DESCRIPTION
Updated HEADER Object to correctly encrypt the data.

- UTF-8 headers now correctly parsed.

A header with utf-8 should be on the mime string as:

"`some text to tést`" → "`=?UTF-8?B?c29tZSB0ZXh0IHRvIHTDqXN0?=`"
