### PR TITLE
DONE: Add sendcontext

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,6 @@
 [run]
 source = ./qreu
+omit = qreu/local.py
+
+[report]
+omit = qreu/local.py

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import email
-from email.encoders import encode_base64
 from email.header import decode_header, Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
@@ -91,7 +90,7 @@ class Email(object):
                 else:
                     result.append(part[0])
             header_value = ''.join(result)
-        
+
         return header_value
 
     def add_header(self, header, value):

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -58,7 +58,7 @@ class Email(object):
     """
     def __init__(self, **kwargs):
         self.email = MIMEMultipart()
-        for header_name in ['to', 'cc', 'bcc', 'subject', 'from', '']:
+        for header_name in ['subject', 'from', 'to', 'cc', 'bcc']:
             value = kwargs.get(header_name, False)
             if not value:
                 continue

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -12,6 +12,7 @@ from html2text import html2text
 import re
 
 from qreu import address
+from qreu.sendcontext import get_current_sender
 
 
 RE_PATTERNS = re.compile('({0})'.format('|'.join(
@@ -72,6 +73,12 @@ class Email(object):
         mail = Email()
         mail.email = email.message_from_string(raw_message)
         return mail
+
+    def send(self):
+        """
+        Send himself using the current sendercontext
+        """
+        return get_current_sender().send(self)
 
     def header(self, header, default=None):
         """

--- a/qreu/local.py
+++ b/qreu/local.py
@@ -1,0 +1,416 @@
+# -*- coding: utf-8 -*-
+"""
+    werkzeug.local
+    ~~~~~~~~~~~~~~
+
+    This module implements context-local objects.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+import copy
+
+# since each thread has its own greenlet we can just use those as identifiers
+# for the context.  If greenlets are not available we fall back to the
+# current thread ident depending on where it is.
+try:
+    from greenlet import getcurrent as get_ident
+except ImportError:
+    try:
+        from thread import get_ident
+    except ImportError:  # noqa
+        try:
+            from _thread import get_ident  # noqa
+        except ImportError:  # noqa
+            from dummy_thread import get_ident  # noqa
+
+
+def release_local(local):
+    """Releases the contents of the local for the current context.
+    This makes it possible to use locals without a manager.
+
+    Example::
+
+        >>> loc = Local()
+        >>> loc.foo = 42
+        >>> release_local(loc)
+        >>> hasattr(loc, 'foo')
+        False
+
+    With this function one can release :class:`Local` objects as well
+    as :class:`LocalStack` objects.  However it is not possible to
+    release data held by proxies that way, one always has to retain
+    a reference to the underlying local object in order to be able
+    to release it.
+
+    .. versionadded:: 0.6.1
+    """
+    local.__release_local__()
+
+
+class Local(object):
+    __slots__ = ('__storage__', '__ident_func__')
+
+    def __init__(self):
+        object.__setattr__(self, '__storage__', {})
+        object.__setattr__(self, '__ident_func__', get_ident)
+
+    def __iter__(self):
+        return iter(self.__storage__.items())
+
+    def __call__(self, proxy):
+        """Create a proxy for a name."""
+        return LocalProxy(self, proxy)
+
+    def __release_local__(self):
+        self.__storage__.pop(self.__ident_func__(), None)
+
+    def __getattr__(self, name):
+        try:
+            return self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        ident = self.__ident_func__()
+        storage = self.__storage__
+        try:
+            storage[ident][name] = value
+        except KeyError:
+            storage[ident] = {name: value}
+
+    def __delattr__(self, name):
+        try:
+            del self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class LocalStack(object):
+
+    """This class works similar to a :class:`Local` but keeps a stack
+    of objects instead.  This is best explained with an example::
+
+        >>> ls = LocalStack()
+        >>> ls.push(42)
+        >>> ls.top
+        42
+        >>> ls.push(23)
+        >>> ls.top
+        23
+        >>> ls.pop()
+        23
+        >>> ls.top
+        42
+
+    They can be force released by using a :class:`LocalManager` or with
+    the :func:`release_local` function but the correct way is to pop the
+    item from the stack after using.  When the stack is empty it will
+    no longer be bound to the current context (and as such released).
+
+    By calling the stack without arguments it returns a proxy that resolves to
+    the topmost item on the stack.
+
+    .. versionadded:: 0.6.1
+    """
+
+    def __init__(self):
+        self._local = Local()
+
+    def __release_local__(self):
+        self._local.__release_local__()
+
+    def _get__ident_func__(self):
+        return self._local.__ident_func__
+
+    def _set__ident_func__(self, value):
+        object.__setattr__(self._local, '__ident_func__', value)
+    __ident_func__ = property(_get__ident_func__, _set__ident_func__)
+    del _get__ident_func__, _set__ident_func__
+
+    def __call__(self):
+        def _lookup():
+            rv = self.top
+            if rv is None:
+                raise RuntimeError('object unbound')
+            return rv
+        return LocalProxy(_lookup)
+
+    def push(self, obj):
+        """Pushes a new item to the stack"""
+        rv = getattr(self._local, 'stack', None)
+        if rv is None:
+            self._local.stack = rv = []
+        rv.append(obj)
+        return rv
+
+    def pop(self):
+        """Removes the topmost item from the stack, will return the
+        old value or `None` if the stack was already empty.
+        """
+        stack = getattr(self._local, 'stack', None)
+        if stack is None:
+            return None
+        elif len(stack) == 1:
+            release_local(self._local)
+            return stack[-1]
+        else:
+            return stack.pop()
+
+    @property
+    def top(self):
+        """The topmost item on the stack.  If the stack is empty,
+        `None` is returned.
+        """
+        try:
+            return self._local.stack[-1]
+        except (AttributeError, IndexError):
+            return None
+
+
+class LocalManager(object):
+
+    """Local objects cannot manage themselves. For that you need a local
+    manager.  You can pass a local manager multiple locals or add them later
+    by appending them to `manager.locals`.  Every time the manager cleans up,
+    it will clean up all the data left in the locals for this context.
+
+    The `ident_func` parameter can be added to override the default ident
+    function for the wrapped locals.
+
+    .. versionchanged:: 0.6.1
+       Instead of a manager the :func:`release_local` function can be used
+       as well.
+
+    .. versionchanged:: 0.7
+       `ident_func` was added.
+    """
+
+    def __init__(self, locals=None, ident_func=None):
+        if locals is None:
+            self.locals = []
+        elif isinstance(locals, Local):
+            self.locals = [locals]
+        else:
+            self.locals = list(locals)
+        if ident_func is not None:
+            self.ident_func = ident_func
+            for local in self.locals:
+                object.__setattr__(local, '__ident_func__', ident_func)
+        else:
+            self.ident_func = get_ident
+
+    def get_ident(self):
+        """Return the context identifier the local objects use internally for
+        this context.  You cannot override this method to change the behavior
+        but use it to link other context local objects (such as SQLAlchemy's
+        scoped sessions) to the Werkzeug locals.
+
+        .. versionchanged:: 0.7
+           You can pass a different ident function to the local manager that
+           will then be propagated to all the locals passed to the
+           constructor.
+        """
+        return self.ident_func()
+
+    def cleanup(self):
+        """Manually clean up the data in the locals for this context.  Call
+        this at the end of the request or use `make_middleware()`.
+        """
+        for local in self.locals:
+            release_local(local)
+
+    def make_middleware(self, app):
+        """Wrap a WSGI application so that cleaning up happens after
+        request end.
+        """
+        def application(environ, start_response):
+            return ClosingIterator(app(environ, start_response), self.cleanup)
+        return application
+
+    def middleware(self, func):
+        """Like `make_middleware` but for decorating functions.
+
+        Example usage::
+
+            @manager.middleware
+            def application(environ, start_response):
+                ...
+
+        The difference to `make_middleware` is that the function passed
+        will have all the arguments copied from the inner application
+        (name, docstring, module).
+        """
+        return update_wrapper(self.make_middleware(func), func)
+
+    def __repr__(self):
+        return '<%s storages: %d>' % (
+            self.__class__.__name__,
+            len(self.locals)
+        )
+
+
+class LocalProxy(object):
+
+    """Acts as a proxy for a werkzeug local.  Forwards all operations to
+    a proxied object.  The only operations not supported for forwarding
+    are right handed operands and any kind of assignment.
+
+    Example usage::
+
+        from werkzeug.local import Local
+        l = Local()
+
+        # these are proxies
+        request = l('request')
+        user = l('user')
+
+
+        from werkzeug.local import LocalStack
+        _response_local = LocalStack()
+
+        # this is a proxy
+        response = _response_local()
+
+    Whenever something is bound to l.user / l.request the proxy objects
+    will forward all operations.  If no object is bound a :exc:`RuntimeError`
+    will be raised.
+
+    To create proxies to :class:`Local` or :class:`LocalStack` objects,
+    call the object as shown above.  If you want to have a proxy to an
+    object looked up by a function, you can (as of Werkzeug 0.6.1) pass
+    a function to the :class:`LocalProxy` constructor::
+
+        session = LocalProxy(lambda: get_current_request().session)
+
+    .. versionchanged:: 0.6.1
+       The class can be instantiated with a callable as well now.
+    """
+    __slots__ = ('__local', '__dict__', '__name__', '__wrapped__')
+
+    def __init__(self, local, name=None):
+        object.__setattr__(self, '_LocalProxy__local', local)
+        object.__setattr__(self, '__name__', name)
+        if callable(local) and not hasattr(local, '__release_local__'):
+            # "local" is a callable that is not an instance of Local or
+            # LocalManager: mark it as a wrapped function.
+            object.__setattr__(self, '__wrapped__', local)
+
+    def _get_current_object(self):
+        """Return the current object.  This is useful if you want the real
+        object behind the proxy at a time for performance reasons or because
+        you want to pass the object into a different context.
+        """
+        if not hasattr(self.__local, '__release_local__'):
+            return self.__local()
+        try:
+            return getattr(self.__local, self.__name__)
+        except AttributeError:
+            raise RuntimeError('no object bound to %s' % self.__name__)
+
+    @property
+    def __dict__(self):
+        try:
+            return self._get_current_object().__dict__
+        except RuntimeError:
+            raise AttributeError('__dict__')
+
+    def __repr__(self):
+        try:
+            obj = self._get_current_object()
+        except RuntimeError:
+            return '<%s unbound>' % self.__class__.__name__
+        return repr(obj)
+
+    def __bool__(self):
+        try:
+            return bool(self._get_current_object())
+        except RuntimeError:
+            return False
+
+    def __unicode__(self):
+        try:
+            return unicode(self._get_current_object())  # noqa
+        except RuntimeError:
+            return repr(self)
+
+    def __dir__(self):
+        try:
+            return dir(self._get_current_object())
+        except RuntimeError:
+            return []
+
+    def __getattr__(self, name):
+        if name == '__members__':
+            return dir(self._get_current_object())
+        return getattr(self._get_current_object(), name)
+
+    def __setitem__(self, key, value):
+        self._get_current_object()[key] = value
+
+    def __delitem__(self, key):
+        del self._get_current_object()[key]
+
+
+    __getslice__ = lambda x, i, j: x._get_current_object()[i:j]
+
+    def __setslice__(self, i, j, seq):
+        self._get_current_object()[i:j] = seq
+
+    def __delslice__(self, i, j):
+        del self._get_current_object()[i:j]
+
+    __setattr__ = lambda x, n, v: setattr(x._get_current_object(), n, v)
+    __delattr__ = lambda x, n: delattr(x._get_current_object(), n)
+    __str__ = lambda x: str(x._get_current_object())
+    __lt__ = lambda x, o: x._get_current_object() < o
+    __le__ = lambda x, o: x._get_current_object() <= o
+    __eq__ = lambda x, o: x._get_current_object() == o
+    __ne__ = lambda x, o: x._get_current_object() != o
+    __gt__ = lambda x, o: x._get_current_object() > o
+    __ge__ = lambda x, o: x._get_current_object() >= o
+    __cmp__ = lambda x, o: cmp(x._get_current_object(), o)  # noqa
+    __hash__ = lambda x: hash(x._get_current_object())
+    __call__ = lambda x, *a, **kw: x._get_current_object()(*a, **kw)
+    __len__ = lambda x: len(x._get_current_object())
+    __getitem__ = lambda x, i: x._get_current_object()[i]
+    __iter__ = lambda x: iter(x._get_current_object())
+    __contains__ = lambda x, i: i in x._get_current_object()
+    __add__ = lambda x, o: x._get_current_object() + o
+    __sub__ = lambda x, o: x._get_current_object() - o
+    __mul__ = lambda x, o: x._get_current_object() * o
+    __floordiv__ = lambda x, o: x._get_current_object() // o
+    __mod__ = lambda x, o: x._get_current_object() % o
+    __divmod__ = lambda x, o: x._get_current_object().__divmod__(o)
+    __pow__ = lambda x, o: x._get_current_object() ** o
+    __lshift__ = lambda x, o: x._get_current_object() << o
+    __rshift__ = lambda x, o: x._get_current_object() >> o
+    __and__ = lambda x, o: x._get_current_object() & o
+    __xor__ = lambda x, o: x._get_current_object() ^ o
+    __or__ = lambda x, o: x._get_current_object() | o
+    __div__ = lambda x, o: x._get_current_object().__div__(o)
+    __truediv__ = lambda x, o: x._get_current_object().__truediv__(o)
+    __neg__ = lambda x: -(x._get_current_object())
+    __pos__ = lambda x: +(x._get_current_object())
+    __abs__ = lambda x: abs(x._get_current_object())
+    __invert__ = lambda x: ~(x._get_current_object())
+    __complex__ = lambda x: complex(x._get_current_object())
+    __int__ = lambda x: int(x._get_current_object())
+    __long__ = lambda x: long(x._get_current_object())  # noqa
+    __float__ = lambda x: float(x._get_current_object())
+    __oct__ = lambda x: oct(x._get_current_object())
+    __hex__ = lambda x: hex(x._get_current_object())
+    __index__ = lambda x: x._get_current_object().__index__()
+    __coerce__ = lambda x, o: x._get_current_object().__coerce__(x, o)
+    __enter__ = lambda x: x._get_current_object().__enter__()
+    __exit__ = lambda x, *a, **kw: x._get_current_object().__exit__(*a, **kw)
+    __radd__ = lambda x, o: o + x._get_current_object()
+    __rsub__ = lambda x, o: o - x._get_current_object()
+    __rmul__ = lambda x, o: o * x._get_current_object()
+    __rdiv__ = lambda x, o: o / x._get_current_object()
+    __rtruediv__ = lambda x, o: x._get_current_object().__rtruediv__(o)
+    __rfloordiv__ = lambda x, o: o // x._get_current_object()
+    __rmod__ = lambda x, o: o % x._get_current_object()
+    __rdivmod__ = lambda x, o: x._get_current_object().__rdivmod__(o)
+    __copy__ = lambda x: copy.copy(x._get_current_object())
+    __deepcopy__ = lambda x, memo: copy.deepcopy(x._get_current_object(), memo)

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -4,7 +4,7 @@ from qreu import local
 
 _SENDCONTEXT = local.LocalStack()
 
-class Sender():
+class Sender(object):
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             self.__setattr__(k, v)
@@ -23,3 +23,19 @@ class Sender():
         :type mail:     Email
         """
         return mail.mime_string
+
+
+class FileSender(Sender):
+    def __init__(self, filename):
+        if not filename:
+            raise ValueError('A filename is required to spawn a FileSender')
+        super(FileSender, self).__init__(_filename=filename)
+
+    def send(self, mail):
+        """
+        Send the qreu.Email object as a string to a file
+        :param mail:    qreu.Email object to send
+        :type mail:     Email
+        """
+        with open(self._filename, 'w') as writer:
+            writer.write(mail.mime_string)

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -2,60 +2,24 @@
 
 from qreu import local
 
+_SENDCONTEXT = local.LocalStack()
 
-class SenderContext():
-    """
-    Context Manager to Send e-mails using werkzeug.local*
+class Sender():
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            self.__setattr__(k, v)
 
-    This manager allows to encapsulate the sender configurations to send the email
-    from qreu.Email in any possible way.
+    def __enter__(self):
+        _SENDCONTEXT.push(self)
+        return _SENDCONTEXT.top
 
-    The configurations appendend to the SenderContext may have a callable method
-    `send_method` and all required argumentsin the self object
+    def __exit__(self, a, b, c):
+        _SENDCONTEXT.pop()
 
-    *: werkzeug.local is subject to copyright under BSD license, see the "local.py"
-    """
-    def __init__(self):
-        self.context_manager = local.LocalManager()
-
-    def add_config(self, **kwargs):
+    def send(self, mail):
         """
-        Adds a new config to the SenderContext
-        The configuration can be provided with two different ways:
-
-        - Provide an already built SenderConfig
-        - Provide all the required parameters via `kwargs`
-
-        :raise ValueError:     If sender_config is provided and isn't
-                                    a valid SenderConfig instance
-        :param sender_config:   A SenderConfig instance to add into the manager
-        :type sender_config:    SenderConfig
-        :param kwargs:          All params required to init a SenderConfig
+        Send the qreu.Email object as a string
+        :param mail:    qreu.Email object to send
+        :type mail:     Email
         """
-        config = local.Local()
-        send_method = kwargs.get('send_method', False)
-        if not send_method or not callable(send_method):
-            raise ValueError(
-                'SenderConfig requires a callable "send_method" argument')
-        for key, value in kwargs.items():
-            if key == 'send_method':
-                config.send = value
-                continue
-            config.__setattr__(name=key, value=value)
-        self.context_manager.locals.append(config)
-
-    def has_configs(self):
-        """
-        Returns boolean indicating if any configuration has been set
-        """
-        return any(self.context_manager.locals)
-
-    @property
-    def configs(self):
-        """
-        Returns all configs with a generator
-        """
-        for config in self.context_manager.locals:
-            yield config
-
-sendcontext = SenderContext()
+        return mail.mime_string

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from qreu import local
+
+
+class SenderContext():
+    """
+    Context Manager to Send e-mails using werkzeug.local*
+
+    This manager allows to encapsulate the sender configurations to send the email
+    from qreu.Email in any possible way.
+
+    The configurations appendend to the SenderContext may have a callable method
+    `send_method` and all required argumentsin the self object
+
+    *: werkzeug.local is subject to copyright under BSD license, see the "local.py"
+    """
+    def __init__(self):
+        self.context_manager = local.LocalManager()
+
+    def add_config(self, **kwargs):
+        """
+        Adds a new config to the SenderContext
+        The configuration can be provided with two different ways:
+
+        - Provide an already built SenderConfig
+        - Provide all the required parameters via `kwargs`
+
+        :raise ValueError:     If sender_config is provided and isn't
+                                    a valid SenderConfig instance
+        :param sender_config:   A SenderConfig instance to add into the manager
+        :type sender_config:    SenderConfig
+        :param kwargs:          All params required to init a SenderConfig
+        """
+        config = local.Local()
+        send_method = kwargs.get('send_method', False)
+        if not send_method or not callable(send_method):
+            raise ValueError(
+                'SenderConfig requires a callable "send_method" argument')
+        for key, value in kwargs.items():
+            if key == 'send_method':
+                config.send = value
+                continue
+            config.__setattr__(name=key, value=value)
+        self.context_manager.locals.append(config)
+
+    def has_configs(self):
+        """
+        Returns boolean indicating if any configuration has been set
+        """
+        return any(self.context_manager.locals)
+
+    @property
+    def configs(self):
+        """
+        Returns all configs with a generator
+        """
+        for config in self.context_manager.locals:
+            yield config
+
+sendcontext = SenderContext()

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from qreu import local
+from smtplib import SMTP
 
 _SENDCONTEXT = local.LocalStack()
 
@@ -13,7 +14,7 @@ class Sender(object):
         _SENDCONTEXT.push(self)
         return _SENDCONTEXT.top
 
-    def __exit__(self, a, b, c):
+    def __exit__(self, etype, evalue, etraceback):
         _SENDCONTEXT.pop()
 
     def send(self, mail):
@@ -39,3 +40,38 @@ class FileSender(Sender):
         """
         with open(self._filename, 'w') as writer:
             writer.write(mail.mime_string)
+
+class SMTPSender(Sender):
+    def __init__(
+            self, host='localhost', port=0, user='', passwd='',
+            ssl_keyfile='', ssl_certfile=''
+    ):
+        super(SMTPSender, self).__init__(
+            _host=host,
+            _port=port,
+            _user=user,
+            _passwd=passwd,
+            _ssl_keyfile=ssl_keyfile,
+            _ssl_certfile=ssl_certfile
+        )
+
+    def __enter__(self):
+        self._connection = SMTP(host=self._host, port=self._port)
+        if self._ssl_keyfile and self._ssl_certfile:
+            self._connection.starttls(
+                keyfile=self._ssl_keyfile, certfile=self._ssl_certfile)
+        if self._user and self._passwd:
+            self._connection.login(user=self._user, password=self._passwd)
+        return super(SMTPSender, self).__enter__()
+
+    def __exit__(self, etype, evalue, etraceback):
+        super(SMTPSender, self).__exit__(etype, evalue, etraceback)
+        self._connection.close()
+
+    def send(self, mail):
+        """
+        Send the qreu.Email object through smtp.sendmail
+        :param mail:    qreu.Email object to send
+        :type mail:     Email
+        """
+        self._connection.sendmail(mail.from_, mail.recipients, mail.mime_string)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 mamba
 expects
+mock

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 from qreu import Email
 from qreu.address import AddressList, Address
+from qreu.sendcontext import Sender
 import qreu.address
 
 from email.mime.multipart import MIMEMultipart
@@ -243,7 +244,7 @@ with description("Creating an Email"):
             def call_wrongly():
                 e = Email()
                 e.add_attachment(False)
-            
+
             expect(call_wrongly).to(raise_error(ValueError))
 
         with it('must raise an exception adding an attachment without name'):
@@ -253,7 +254,7 @@ with description("Creating an Email"):
                 e = Email()
                 input_iostr = StringIO('Test string on StringIO')
                 e.add_attachment(input_iostr)
-            
+
             expect(call_wrongly).to(raise_error(ValueError))
 
     with context("using kwargs"):
@@ -327,3 +328,8 @@ with description("Creating an Email"):
             expect(
                 Email.parse(e.mime_string).mime_string
             ).to(equal(e.mime_string))
+
+        with it('must send himself using current sendcontext'):
+            e = Email(**self.vals)
+            with Sender():
+                expect(e.send()).to(equal(e.mime_string))

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -7,19 +7,10 @@ from qreu import Email
 from mamba import *
 from expects import *
 
-with description('Simple SenderManager'):
-    with context('simple configuration'):
-        with before.all:
-            def send_true(mail):
-                return True
-            self.manager = sendcontext.SenderContext()
-            self.send_true = send_true
-            self.test_mail = Email()
-        with it('must create a new simple configuration'):
-            expect(self.manager.has_configs()).to(be_false)
-            self.manager.add_config(send_method=self.send_true)
-            expect(self.manager.has_configs()).to(be_true)
-
-        with it('must "send" correctly any email from config'):
-            for config in self.manager.configs:
-                expect(config.send(self.test_mail)).to(be_true)
+with description('Sendcontext'):
+    with before.all:
+        self.test_mail = Email()
+    with it('must return the mail as a string with default Sender'):
+        with sendcontext.Sender() as sender:
+            expect(sender.send(self.test_mail)).to(
+                equal(self.test_mail.mime_string))

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -11,6 +11,16 @@ from qreu import Email
 
 with description('Sendcontext'):
     with before.all:
+        class TempDir(object):
+            def __init__(self):
+                self.dir = tempfile.mkdtemp()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                shutil.rmtree(self.dir)
+        self.temp_dir = TempDir
         self.test_mail = Email(
             From='me@example.com',
             To='you@example.com',
@@ -26,16 +36,7 @@ with description('Sendcontext'):
                 equal(self.test_mail.mime_string))
 
     with it('must write the mail as a string to a file with FileSender'):
-        class TempDir(object):
-            def __init__(self):
-                self.dir = tempfile.mkdtemp()
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                shutil.rmtree(self.dir)
-        with TempDir() as tmpdir:
+        with self.temp_dir() as tmpdir:
             filename = tempfile.mktemp(dir=tmpdir.dir)
             with FileSender(filename) as sender:
                 sender.send(self.test_mail)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from qreu import sendcontext
+
+from mamba import *
+from expects import *
+
+with description('Simple SenderManager'):
+    with it(
+        'must create a new configuration, add it to SenderManager'
+        ' and be able to send'
+    ):
+        def send_true():
+            return True
+        manager = sendcontext.SenderContext()
+        manager.add_config(send_method=send_true)
+        expect(manager.has_configs()).to(be_true)
+        expect([c.send() for c in manager.configs]).to(equal([True]))

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -2,18 +2,24 @@
 from __future__ import absolute_import, unicode_literals
 
 from qreu import sendcontext
+from qreu import Email
 
 from mamba import *
 from expects import *
 
 with description('Simple SenderManager'):
-    with it(
-        'must create a new configuration, add it to SenderManager'
-        ' and be able to send'
-    ):
-        def send_true():
-            return True
-        manager = sendcontext.SenderContext()
-        manager.add_config(send_method=send_true)
-        expect(manager.has_configs()).to(be_true)
-        expect([c.send() for c in manager.configs]).to(equal([True]))
+    with context('simple configuration'):
+        with before.all:
+            def send_true(mail):
+                return True
+            self.manager = sendcontext.SenderContext()
+            self.send_true = send_true
+            self.test_mail = Email()
+        with it('must create a new simple configuration'):
+            expect(self.manager.has_configs()).to(be_false)
+            self.manager.add_config(send_method=self.send_true)
+            expect(self.manager.has_configs()).to(be_true)
+
+        with it('must "send" correctly any email from config'):
+            for config in self.manager.configs:
+                expect(config.send(self.test_mail)).to(be_true)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from qreu import sendcontext
+from qreu.sendcontext import *
 from qreu import Email
 
 from mamba import *
@@ -9,8 +9,29 @@ from expects import *
 
 with description('Sendcontext'):
     with before.all:
-        self.test_mail = Email()
+        self.test_mail = Email(
+            From='me@example.com',
+            To='you@example.com',
+            Subject='test_email',
+            body_text='''
+            This is a test email.
+            If you recieved this email, it means we sent it correctly.
+            '''
+        )
     with it('must return the mail as a string with default Sender'):
-        with sendcontext.Sender() as sender:
+        with Sender() as sender:
             expect(sender.send(self.test_mail)).to(
                 equal(self.test_mail.mime_string))
+
+    with _it('must write the mail as a string to a file with FileSender'):
+        filename = 'test_filesender'
+        with FileSender(filename) as sender:
+            sender.send(self.test_mail)
+        with open(filename, 'r') as test_file:
+            mail_text = test_file.read()
+        expect(mail_text).to(equal(self.test_mail.mime_string))
+
+    with _it('must "send" via smtp the email with SMTPSender'):
+        # TODO: Mock it
+        with SMTPSender(host='', user='', passwd='', ssl=True) as sender:
+            sender.send(self.test_mail)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -9,7 +9,7 @@ import tempfile
 from qreu.sendcontext import *
 from qreu import Email
 
-with description('Sendcontext'):
+with description('Senders'):
     with before.all:
         class TempDir(object):
             def __init__(self):
@@ -77,3 +77,10 @@ with description('Sendcontext'):
                         equal(self.test_mail.mime_string))
                 expect(base_sender.send(self.test_mail)).to(
                     equal(self.test_mail.mime_string))
+
+    with context('Bad Sender inits'):
+        with it('must raise ValueError if no filename provided to FileSender'):
+            def call_wrongly():
+                FileSender(False)
+
+            expect(call_wrongly).to(raise_error(ValueError))

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -23,7 +23,7 @@ with description('Sendcontext'):
             expect(sender.send(self.test_mail)).to(
                 equal(self.test_mail.mime_string))
 
-    with _it('must write the mail as a string to a file with FileSender'):
+    with it('must write the mail as a string to a file with FileSender'):
         filename = 'test_filesender'
         with FileSender(filename) as sender:
             sender.send(self.test_mail)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -7,6 +7,8 @@ from qreu import Email
 from mamba import *
 from expects import *
 
+from mock import patch, Mock
+
 with description('Sendcontext'):
     with before.all:
         self.test_mail = Email(
@@ -31,7 +33,22 @@ with description('Sendcontext'):
             mail_text = test_file.read()
         expect(mail_text).to(equal(self.test_mail.mime_string))
 
-    with _it('must "send" via smtp the email with SMTPSender'):
-        # TODO: Mock it
-        with SMTPSender(host='', user='', passwd='', ssl=True) as sender:
-            sender.send(self.test_mail)
+    with it('must "send" via smtp the email with SMTPSender'):
+        with patch('qreu.sendcontext.SMTP') as mocked_conn:
+            # Mock the SMTP connection
+            smtp_mocked = Mock()
+            smtp_mocked.login.return_value = True
+            smtp_mocked.starttls.return_value = True
+            smtp_mocked.login.return_value = True
+            smtp_mocked.send.return_value = True
+            smtp_mocked.sendmail.return_value = True
+            smtp_mocked.close.return_value = True
+            mocked_conn.return_value = smtp_mocked
+            with SMTPSender(
+                host='host',
+                user='user',
+                passwd='passwd',
+                ssl_keyfile='ssl_keyfile',
+                ssl_certfile='ssl_certfile'
+            ) as sender:
+                sender.send(self.test_mail)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -63,3 +63,17 @@ with description('Sendcontext'):
                 ssl_certfile='ssl_certfile'
             ) as sender:
                 sender.send(self.test_mail)
+
+    with it('must send different emails on multi-layered contexts'):
+        with self.temp_dir() as tmpdir:
+            filename = tempfile.mktemp(dir=tmpdir.dir)
+            with Sender() as base_sender:
+                expect(base_sender.send(self.test_mail)).to(
+                    equal(self.test_mail.mime_string))
+                with FileSender(filename) as file_sender:
+                    file_sender.send(self.test_mail)
+                with open(filename, 'r') as file_mail:
+                    expect(file_mail.read()).to(
+                        equal(self.test_mail.mime_string))
+                expect(base_sender.send(self.test_mail)).to(
+                    equal(self.test_mail.mime_string))


### PR DESCRIPTION
Closes #8

Adds:
- Werkzeug's local manager.
- [x] Sender class
  - A Base class that can be used within a context manager (Tag `with:`)
  - This class also registers all kwargs provided
  - This class also have the `send()` method to send the qreu.Email. By default, return the mail as a string.
- [x] FileSender class
  - A subclass of Sender that writes the email within a file
- [x] SMTPSender class
  - A sublass of Sender that sends the email through an SMTP connection
- [x] Test multi-layered Senders on Context Manager