### PR TITLE
DONE: Fix header parse

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -74,6 +74,50 @@ class Email(object):
         mail.email = email.message_from_string(raw_message)
         return mail
 
+    @staticmethod
+    def fix_header_name(header_name):
+        """
+        Fix header names according to RFC 4021:
+        https://tools.ietf.org/html/rfc4021#section-2.1.5
+        :param header_name: Name of the header to fix
+        :type header_name:  str
+        :return:            Fixed name of the header
+        :rtype:             str
+        """
+        headers = [
+            'Date', 'From', 'Sender', 'Reply-To', 'To', 'Cc', 'Bcc',
+            'Message-ID', 'In-Reply-To', 'References', 'Subject', 'Comments',
+            'Keywords', 'Resent-Date', 'Resent-From', 'Resent-Sender',
+            'Resent-To', 'Resent-Cc', 'Resent-Bcc', 'Resent-Reply-To',
+            'Resent-Message-ID', 'Return-Path', 'Received', 'Encrypted',
+            'Disposition-Notification-To', 'Disposition-Notification-Options',
+            'Accept-Language', 'Original-Message-ID', 'PICS-Label', 'Encoding',
+            'List-Archive', 'List-Help', 'List-ID', 'List-Owner', 'List-Post',
+            'List-Subscribe', 'List-Unsubscribe', 'Message-Context',
+            'DL-Expansion-History', 'Alternate-Recipient',
+            'Original-Encoded-Information-Types', 'Content-Return',
+            'Generate-Delivery-Report', 'Prevent-NonDelivery-Report',
+            'Obsoletes', 'Supersedes', 'Content-Identifier', 'Delivery-Date',
+            'Expiry-Date', 'Expires', 'Reply-By', 'Importance',
+            'Incomplete-Copy', 'Priority', 'Sensitivity', 'Language',
+            'Conversion', 'Conversion-With-Loss', 'Message-Type',
+            'Autosubmitted', 'Autoforwarded', 'Discarded-X400-IPMS-Extensions',
+            'Discarded-X400-MTS-Extensions', 'Disclose-Recipients',
+            'Deferred-Delivery', 'Latest-Delivery-Time',
+            'Originator-Return-Address', 'X400-Content-Identifier',
+            'X400-Content-Return', 'X400-Content-Type', 'X400-MTS-Identifier',
+            'X400-Originator', 'X400-Received', 'X400-Recipients', 'X400-Trace',
+            'MIME-Version', 'Content-ID', 'Content-Description',
+            'Content-Transfer-Encoding', 'Content-Type', 'Content-Base',
+            'Content-Location', 'Content-features', 'Content-Disposition',
+            'Content-Language', 'Content-Alternative', 'Content-MD5',
+            'Content-Duration',
+        ]
+        for header in headers:
+            if header_name.lower() == header.lower():
+                return header
+        return ''
+
     def header(self, header, default=None):
         """
         Get the email Header always in Unicode
@@ -111,6 +155,7 @@ class Email(object):
         if isinstance(value, list) and header.lower() in recipients_headers:
             value = ','.join(value)
         header_value = Header(value, charset='utf-8').encode()
+        header = Email.fix_header_name(header)
         self.email[header] = header_value
         return header_value
 

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -135,7 +135,6 @@ class Email(object):
                 else:
                     result.append(part[0])
             header_value = ''.join(result)
-        
         return header_value
 
     def add_header(self, header, value):
@@ -152,10 +151,14 @@ class Email(object):
         if not (header and value):
             raise ValueError('Header not provided!')
         recipients_headers = ['to', 'cc', 'bcc']
-        if isinstance(value, list) and header.lower() in recipients_headers:
-            value = ','.join(value)
-        header_value = Header(value, charset='utf-8').encode()
-        header = Email.fix_header_name(header)
+        if header.lower() in recipients_headers:
+            if isinstance(value, list):
+                value = ','.join(value)
+            header_value = str(value)
+        else:
+            header_value = Header(value, charset='utf-8').encode()
+        # Get correct header name or add the one provided if custom header key
+        header = Email.fix_header_name(header) or header
         self.email[header] = header_value
         return header_value
 

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -168,7 +168,7 @@ class Email(object):
                 #    so the item is encoded properly
                 # - The encoded display name and the address are joined
                 #    into the Header of the email
-                mail_addr = address.parse(str(addr))
+                mail_addr = address.parse(addr)
                 display_name = Header(
                     mail_addr.display_name, charset='utf-8').encode()
                 if display_name:

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import email
-from email.utils import formataddr
 from email.header import decode_header, Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     packages=find_packages(),
     url='https://github.com/gisce/qreu',
     install_requires=[
-        'html2text'
+        'html2text',
+        'six'
     ],
     license='MIT',
     author='GISCE-TI, S.L.',

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -312,12 +312,13 @@ with description("Creating an Email"):
 
         with it('must add addresses correctly as "name" <address>'):
             address = 'spécial <special@example.com>'
+            parsed = 'spécial<special@example.com>'
             e = Email(to=address)
-            expect(e.to).to(equal([address]))
+            expect(e.to).to(equal([parsed]))
             e = Email(cc=address)
-            expect(e.cc).to(equal([address]))
+            expect(e.cc).to(equal([parsed]))
             e = Email(bcc=[address])
-            expect(e.bcc).to(equal([address]))
+            expect(e.bcc).to(equal([parsed]))
 
         with it('must parse html2text if no text provided'):
             vals = self.vals.copy()

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -106,12 +106,17 @@ with description("Creating an Email"):
             expect(e.cc).to(be_empty)
             expect(e.recipients).to(be_empty)
 
-        with it('must add header to Email'):
+        with it('must add any header to Email'):
             e = Email()
             header_key = 'X-ORIG-HEADER'
             header_value = 'Header String Value'
             expect(e.header(header_key, False)).to(be_false)
+            # Custom Header
             e.add_header(header_key, header_value)
+            # Recipient Header using an address
+            e.add_header('to', 'someone@example.com')
+            # Recipient Header using a list
+            e.add_header('cc', ['someone@example.com', 'theboss@example.com'])
             expect(e.header(header_key, False)).to(equal(header_value))
 
         with it('must raise exception wrongly adding a header'):
@@ -147,7 +152,7 @@ with description("Creating an Email"):
             expect(e.body_parts).to(have_keys('plain', 'html'))
             expect(e.body_parts['plain']).to(equal(plain))
             expect(e.body_parts['html']).to(equal(html))
-  
+
         with it('must raise ValueError if no body provided on add_body'):
             e = Email()
             expect(e.add_body_text).to(raise_error(ValueError))
@@ -311,7 +316,7 @@ with description("Creating an Email"):
             expect(e.to).to(equal([address]))
             e = Email(cc=address)
             expect(e.cc).to(equal([address]))
-            e = Email(bcc=address)
+            e = Email(bcc=[address])
             expect(e.bcc).to(equal([address]))
 
         with it('must parse html2text if no text provided'):


### PR DESCRIPTION
Properly add the headers on the email object so the clients correctly show the values (Finally!)

- Correct the header names with the default names according to the [RFC 4021](https://tools.ietf.org/html/rfc4021#section-2.1.5)
- Treat the recipient headers as strings so the encoding won't cover the value (as [email formataddr](https://docs.python.org/2/library/email.util.html#email.utils.formataddr) method does)