### PR TITLE
Add Date Header on new Email

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -6,6 +6,7 @@ from email.header import decode_header, Header
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from datetime import datetime
 
 from html2text import html2text
 from six import PY2
@@ -64,6 +65,13 @@ class Email(object):
             if not value:
                 continue
             self.add_header(header_name, value)
+        # Add date with "Thu, 01 Mar 2018 12:30:03 -0000" format
+        now = datetime.now()
+        if now.tzname():
+            now = now.strftime('%a, %d %%b %Y %H:%M:%S -%z (%Z)')
+        else:
+            now = now.strftime('%a, %d %%b %Y %H:%M:%S -%z')
+        self.add_header('Date', kwargs.get('date', now))
         body_text = kwargs.get('body_text', False)
         body_html = kwargs.get('body_html', False)
         if body_text or body_html:

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -66,16 +66,27 @@ class Email(object):
                 continue
             self.add_header(header_name, value)
         # Add date with "Thu, 01 Mar 2018 12:30:03 -0000" format
-        now = datetime.now()
-        if now.tzname():
-            now = now.strftime('%a, %d %%b %Y %H:%M:%S -%z (%Z)')
-        else:
-            now = now.strftime('%a, %d %%b %Y %H:%M:%S -%z')
-        self.add_header('Date', kwargs.get('date', now))
+        self.add_header(
+            'Date', self.format_date(kwargs.get('date', datetime.now()))
+        )
         body_text = kwargs.get('body_text', False)
         body_html = kwargs.get('body_html', False)
         if body_text or body_html:
             self.add_body_text(body_text, body_html)
+
+    @staticmethod
+    def format_date(date_time):
+        """
+        Parses a datetime object to a string with the standard Datetime prompt
+        If no datetime provided, returns the parameter
+        """
+        if not isinstance(date_time, datetime):
+            return date_time
+        elif date_time.tzname():
+            return date_time.strftime('%a, %d %%b %Y %H:%M:%S %z (%Z)')
+        else:
+            return date_time.strftime('%a, %d %%b %Y %H:%M:%S -0000')
+        
 
     @staticmethod
     def parse(raw_message):

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -275,10 +275,8 @@ class Email(object):
         if input_buff:
             attachment_str = base64.encodestring(
                 input_buff.read().encode('utf-8'))
-        elif input_b64:
-            attachment_str = input_b64
         else:
-            raise ValueError('No attachment provided!')
+            attachment_str = input_b64
 
         attachment = MIMEApplication('', _subtype='octet-stream')
         attachment.set_charset('utf-8')

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -133,7 +133,7 @@ with description("Creating an Email"):
             class timezone(tzinfo):
 
                 def tzname(self, dt):
-                    return 'Custom'
+                    return str('Custom')
 
                 def utcoffset(self, dt):
                     diff = (

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from qreu import Email
 from qreu.address import AddressList, Address
 from qreu.sendcontext import Sender
+from datetime import datetime, tzinfo, timedelta
+from mock import patch
 import qreu.address
 
 from email.mime.multipart import MIMEMultipart
@@ -108,10 +110,47 @@ with description("Creating an Email"):
             expect(e.recipients).to(be_empty)
 
         with it('must add date to Header on create'):
-            from datetime import datetime
-            d = datetime.now().strftime('%a, %d %%b %Y %H:%M:%S -%z')
+            d = datetime.now()
+            e = Email()
+            expect(e.header('Date')).to(equal(
+                d.strftime('%a, %d %%b %Y %H:%M:%S -0000')
+            ))
+
+        with it('must add date to Header on create providing a String'):
+            d = datetime.now().strftime('%a, %d %%b %Y %H:%M:%S -0000')
             e = Email(date=d)
             expect(e.header('Date')).to(equal(d))
+
+        with it('must add date to Header on create providing a Datetime'):
+            d = datetime.now()
+            e = Email(date=d)
+            expect(e.header('Date')).to(equal(
+                d.strftime('%a, %d %%b %Y %H:%M:%S -0000')
+            ))
+
+        with it('must add date to Header on create providing a'
+                ' TZ Aware Datetime'):
+            class timezone(tzinfo):
+
+                def tzname(self, dt):
+                    return 'Custom'
+
+                def utcoffset(self, dt):
+                    diff = (
+                        timedelta(hours=dt.hour, minutes=dt.minute) + 
+                        timedelta(hours=1, minutes=23)
+                    )
+                    return diff
+
+                def dst(self, dt):
+                    return self.utcoffset(dt)
+
+            info = timezone()
+            d = datetime.now(tz=info)
+            e = Email(date=d)
+            expect(e.header('Date')).to(equal(
+                d.strftime('%a, %d %%b %Y %H:%M:%S %z (%Z)')
+            ))
 
         with it('must add any header to Email'):
             e = Email()

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -107,6 +107,12 @@ with description("Creating an Email"):
             expect(e.cc).to(be_empty)
             expect(e.recipients).to(be_empty)
 
+        with it('must add date to Header on create'):
+            from datetime import datetime
+            d = datetime.now().strftime('%a, %d %%b %Y %H:%M:%S -%z')
+            e = Email(date=d)
+            expect(e.header('Date')).to(equal(d))
+
         with it('must add any header to Email'):
             e = Email()
             header_key = 'X-ORIG-HEADER'


### PR DESCRIPTION
Date header is mandatory for some email managers to work properly according to the recieve dates of the emails, but we are not adding it by default.

Add missing Date Header for new Email objects.

- [x] ADD missing kwarg for Date on new Email object
- [x] ADD default Date on new Email object as NOW.
