### PR TITLE
Fix SMTP connection init with SMTP_SSL when required

### DIFF
--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -83,7 +83,7 @@ class SMTPSender(Sender):
                                             keyfile=self._ssl_keyfile,
                                             certfile=self._ssl_certfile)
             else:
-                raise err
+                raise
         if self._user and self._passwd:
             self._connection.login(user=self._user, password=self._passwd)
         return super(SMTPSender, self).__enter__()

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -76,7 +76,8 @@ class SMTPSender(Sender):
             if self._tls:
                 self._connection.starttls(
                     keyfile=self._ssl_keyfile, certfile=self._ssl_certfile)
-        except Exception as err:
+        except SMTPConnectError as err:
+            # Cannot establish connection due to only listening to SSL
             if self._tls:
                 self._connection = SMTP_SSL(host=self._host, port=self._port,
                                             keyfile=self._ssl_keyfile,

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -2,7 +2,7 @@
 
 from qreu import local
 from qreu.address import Address
-from smtplib import SMTP, SMTP_SSL
+from smtplib import SMTP, SMTP_SSL, SMTPConnectError
 
 _SENDCONTEXT = local.LocalStack()
 

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -8,6 +8,7 @@ import tempfile
 
 from qreu.sendcontext import *
 from qreu import Email
+from smtplib import SMTPException, SMTPConnectError
 
 with description('Senders'):
     with before.all:
@@ -91,7 +92,7 @@ with description('Senders'):
 
         with it('must try SMTP_SSL connection after failure if TLS is enabled'):
             with patch('qreu.sendcontext.SMTP') as msmtp:
-                msmtp.side_effect = Exception('Try SSL')
+                msmtp.side_effect = SMTPConnectError(255, 'Try SSL')
                 with patch('qreu.sendcontext.SMTP_SSL') as msmtp_ssl:
                     smtp_mocked = Mock()
                     smtp_mocked.login.return_value = True
@@ -121,5 +122,5 @@ with description('Senders'):
                 ) as sender:
                     expect(sender.send(self.test_mail)).to(be_true)
             with patch('qreu.sendcontext.SMTP') as msmtp:
-                msmtp.side_effect = Exception('Failure')
+                msmtp.side_effect = SMTPException('Failure')
                 expect(call_wrongly).to(raise_error)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -8,7 +8,7 @@ import tempfile
 
 from qreu.sendcontext import *
 from qreu import Email
-from smtplib import SMTPException, SMTPConnectError
+from smtplib import SMTPConnectError
 
 with description('Senders'):
     with before.all:
@@ -92,7 +92,8 @@ with description('Senders'):
 
         with it('must try SMTP_SSL connection after failure if TLS is enabled'):
             with patch('qreu.sendcontext.SMTP') as msmtp:
-                msmtp.side_effect = SMTPConnectError(255, 'Try SSL')
+                msmtp.side_effect = SMTPConnectError(
+                    530, "5.7.0 Must issue a STARTTLS command first.")
                 with patch('qreu.sendcontext.SMTP_SSL') as msmtp_ssl:
                     smtp_mocked = Mock()
                     smtp_mocked.login.return_value = True
@@ -122,5 +123,6 @@ with description('Senders'):
                 ) as sender:
                     expect(sender.send(self.test_mail)).to(be_true)
             with patch('qreu.sendcontext.SMTP') as msmtp:
-                msmtp.side_effect = SMTPException('Failure')
+                msmtp.side_effect = SMTPConnectError(
+                    530, "5.7.0 Must issue a STARTTLS command first.")
                 expect(call_wrongly).to(raise_error)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -30,39 +30,6 @@ with description('Senders'):
             If you recieved this email, it means we sent it correctly.
             '''
         )
-    with it('must return the mail as a string with default Sender'):
-        with Sender() as sender:
-            expect(sender.send(self.test_mail)).to(
-                equal(self.test_mail.mime_string))
-
-    with it('must write the mail as a string to a file with FileSender'):
-        with self.temp_dir() as tmpdir:
-            filename = tempfile.mktemp(dir=tmpdir.dir)
-            with FileSender(filename) as sender:
-                sender.send(self.test_mail)
-            with open(filename, 'r') as test_file:
-                mail_text = test_file.read()
-            expect(mail_text).to(equal(self.test_mail.mime_string))
-
-    with it('must "send" via smtp the email with SMTPSender'):
-        with patch('qreu.sendcontext.SMTP') as mocked_conn:
-            # Mock the SMTP connection
-            smtp_mocked = Mock()
-            smtp_mocked.login.return_value = True
-            smtp_mocked.starttls.return_value = True
-            smtp_mocked.login.return_value = True
-            smtp_mocked.send.return_value = True
-            smtp_mocked.sendmail.return_value = True
-            smtp_mocked.close.return_value = True
-            mocked_conn.return_value = smtp_mocked
-            with SMTPSender(
-                host='host',
-                user='user',
-                passwd='passwd',
-                ssl_keyfile='ssl_keyfile',
-                ssl_certfile='ssl_certfile'
-            ) as sender:
-                sender.send(self.test_mail)
 
     with it('must send different emails on multi-layered contexts'):
         with self.temp_dir() as tmpdir:
@@ -84,3 +51,40 @@ with description('Senders'):
                 FileSender(False)
 
             expect(call_wrongly).to(raise_error(ValueError))
+
+    with context('Default (DEBUG) Sender'):
+        with it('must return the mail as a string with default Sender'):
+            with Sender() as sender:
+                expect(sender.send(self.test_mail)).to(
+                    equal(self.test_mail.mime_string))
+
+    with context('FILE Sender'):
+        with it('must write the mail as a string to a file with FileSender'):
+            with self.temp_dir() as tmpdir:
+                filename = tempfile.mktemp(dir=tmpdir.dir)
+                with FileSender(filename) as sender:
+                    sender.send(self.test_mail)
+                with open(filename, 'r') as test_file:
+                    mail_text = test_file.read()
+                expect(mail_text).to(equal(self.test_mail.mime_string))
+
+    with context('SMTP Sender'):
+        with it('must "send" via smtp the email with SMTPSender'):
+            with patch('qreu.sendcontext.SMTP') as mocked_conn:
+                # Mock the SMTP connection
+                smtp_mocked = Mock()
+                smtp_mocked.login.return_value = True
+                smtp_mocked.starttls.return_value = True
+                smtp_mocked.login.return_value = True
+                smtp_mocked.send.return_value = True
+                smtp_mocked.sendmail.return_value = True
+                smtp_mocked.close.return_value = True
+                mocked_conn.return_value = smtp_mocked
+                with SMTPSender(
+                        host='host',
+                        user='user',
+                        passwd='passwd',
+                        ssl_keyfile='ssl_keyfile',
+                        ssl_certfile='ssl_certfile'
+                ) as sender:
+                    sender.send(self.test_mail)


### PR DESCRIPTION
Closes #23 

Try to connect with SMTP and then start TLS if TLS is enabled.
If it fails to connect and TLS is enabled, try to connect directly with SMTP_SSL.

Using exceptions as specified on [SMTP's docs](https://docs.python.org/2/library/smtplib.html):

- SMTPConnectionError may be thrown due to bad connection to a server listening only to SSL port
  - If that's the case, we'll try to connect directly to SSL
  - Else, raise the exception shown

Also improved test data according to the fail message on no SSL/TSL connection as first message (https://support.google.com/a/answer/3726730?hl=en)

----
_NOTE: I don't know if there's a more polite way of doing this._