### PR TITLE
SMTP Sender: Correctly send to all recipients

### DIFF
--- a/qreu/address.py
+++ b/qreu/address.py
@@ -21,8 +21,9 @@ def parse_list(header):
     """Parse a emails string using getaddresses.
     """
     if not header:
-        header = []
-    return AddressList([header])
+        return AddressList([])
+    else:
+        return AddressList([header])
 
 
 class AddressList(UserList):

--- a/qreu/address.py
+++ b/qreu/address.py
@@ -13,12 +13,14 @@ Address = namedtuple('Address', ['display_name', 'address'])
 
 def parse(header):
     """Parse email string using `parseaddr`
+    :return: `Address` from parsing the address on `header`
     """
     return Address(*parseaddr(header))
 
 
 def parse_list(header):
     """Parse a emails string using getaddresses.
+    :return: `AddressList` from `header`
     """
     if not header:
         return AddressList([])

--- a/qreu/address.py
+++ b/qreu/address.py
@@ -21,7 +21,7 @@ def parse_list(header):
     """Parse a emails string using getaddresses.
     """
     if not header:
-        return []
+        header = []
     return AddressList([header])
 
 

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -376,27 +376,35 @@ class Email(object):
 
         :return: `address.AddressList`
         """
-        return address.parse_list(self.header('To', '')).addresses
+        return address.parse_list(self.header('To', ''))
 
     @property
     def cc(self):
         """
         :return: `address.AddressList`
         """
-        return address.parse_list(self.header('Cc', '')).addresses
+        return address.parse_list(self.header('Cc', ''))
 
     @property
     def bcc(self):
         """
         :return: `address.AddressList`
         """
-        return address.parse_list(
-            self.header('Bcc', '') or self.bccs
-        ).addresses
+        return address.parse_list(self.header('Bcc', '') or self.bccs)
 
     @property
     def recipients(self):
+        """
+        :return: `address.AddressList` with all recipients
+        """
         return self.to + self.cc + self.bcc
+
+    @property
+    def recipients_addresses(self):
+        """
+        :return: `list` with all email addresses of the recipients in a list
+        """
+        return list(set(self.recipients.addresses))
 
     @property
     def body_parts(self):

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -376,14 +376,14 @@ class Email(object):
 
         :return: `address.AddressList`
         """
-        return address.parse_list(self.header('To', ''))
+        return address.parse_list(self.header('To', '')).addresses
 
     @property
     def cc(self):
         """
         :return: `address.AddressList`
         """
-        return address.parse_list(self.header('Cc', ''))
+        return address.parse_list(self.header('Cc', '')).addresses
 
     @property
     def bcc(self):
@@ -392,7 +392,7 @@ class Email(object):
         """
         return address.parse_list(
             self.header('Bcc', '') or self.bccs
-        )    
+        ).addresses
 
     @property
     def recipients(self):

--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -92,5 +92,6 @@ class SMTPSender(Sender):
         from_mail = mail.from_
         if isinstance(mail.from_, Address):
             from_mail = from_mail.address
-        self._connection.sendmail(from_mail, mail.recipients, mail.mime_string)
+        self._connection.sendmail(
+            from_mail, mail.recipients_addresses, mail.mime_string)
         return True

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -108,6 +108,7 @@ with description("Creating an Email"):
             expect(e.to).to(be_empty)
             expect(e.cc).to(be_empty)
             expect(e.recipients).to(be_empty)
+            expect(e.recipients.addresses).to(be_empty)
             expect(e.bcc).to(be_empty)
             expect(e.bccs).to(be_empty)
 


### PR DESCRIPTION
## Bug Found

- Mail sending with SMTP and several CC addresses was sending only to the first and last address on CC.
- Making and AddressList from an empty header was returning an empty list instead of an empty AddressList.

## Tasks

- [x] SMTP Sender sendmail should use recipient_addresses (of type `list`) instead of `recipients` (of type `AddressList`)
- [x] `address.parse_list` should always return an instance of a `AddressList` even if it's empty