### PR TITLE
Fix the attachment and body parts getting

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -427,8 +427,9 @@ class Email(object):
             # Get Text and HTML
             elif maintype == 'text':
                 if subtype in ['plain', 'html']:
+                    encoder = part.get_content_charset() or 'utf-8'
                     return_vals.update(
-                        {subtype:part.get_payload(decode=True).decode('utf-8')})
+                        {subtype:part.get_payload(decode=True).decode(encoder)})
             # Get Attachments
             else:
                 files = return_vals.get('files', [])

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -425,12 +425,12 @@ class Email(object):
             if maintype == 'multipart':
                 continue
             # Get Text and HTML
-            if maintype == 'text':
+            elif maintype == 'text':
                 if subtype in ['plain', 'html']:
                     return_vals.update(
                         {subtype:part.get_payload(decode=True).decode('utf-8')})
             # Get Attachments
-            if maintype == 'application':
+            else:
                 files = return_vals.get('files', [])
                 new_attach = part.get('Content-Disposition', False)
                 if 'attachment' in new_attach:
@@ -449,12 +449,16 @@ class Email(object):
         :return: Returns a Tuple generator as (AttachName, AttachContent)
         """
         for part in self.email.walk():
-            if part.get_content_maintype() == 'application':
+            if not part.get_content_maintype() in ['multipart', 'text']:
                 new_attach = part.get('Content-Disposition', False)
                 if 'attachment' in new_attach:
                     filename = new_attach.split('filename=')[-1][1:-1]
                     if filename:
-                        yield filename, part.get_payload()
+                        yield {
+                            'type': part.get_content_type(),
+                            'name': filename,
+                            'content': part.get_payload()
+                        }
 
     @property
     def mime_string(self):

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -433,8 +433,10 @@ class Email(object):
             else:
                 files = return_vals.get('files', [])
                 new_attach = part.get('Content-Disposition', False)
-                if 'attachment' in new_attach:
-                    filename = new_attach.split('filename=')[-1][1:-1]
+                if 'filename' in new_attach:
+                    filename = [
+                         f for f in new_attach.split(';') if 'filename=' in f
+                    ][0].split('filename=')[-1][1:-1]
                     if filename:
                         files.append(filename)
                 return_vals['files'] = files
@@ -451,9 +453,11 @@ class Email(object):
         for part in self.email.walk():
             if not part.get_content_maintype() in ['multipart', 'text']:
                 new_attach = part.get('Content-Disposition', False)
-                if 'attachment' in new_attach:
-                    filename = new_attach.split('filename=')[-1][1:-1]
-                    if filename:
+                if 'filename' in new_attach:
+                    if 'filename' in new_attach:
+                        filename = [
+                            f for f in new_attach.split(';') if 'filename=' in f
+                        ][0].split('filename=')[-1][1:-1]
                         yield {
                             'type': part.get_content_type(),
                             'name': filename,

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -270,9 +270,11 @@ with description("Creating an Email"):
             expect(e.body_parts['files']).to(equal([f_name]))
             with open(f_path) as f:
                 expect(e.add_attachment(input_buff=f)).to(be_true)
-            files = [filename for filename, filecontent in e.attachments]
+            files = [attachment['name'] for attachment in e.attachments]
             expect(files).to(equal([f_name, f_name]))
-            for filename, filecontent in e.attachments:
+            for attachment in e.attachments:
+                filename = attachment['name']
+                filecontent = attachment['content']
                 with open(f_path) as f:
                     attachment_str = base64.encodestring(
                         f.read().encode('utf-8'))
@@ -303,7 +305,9 @@ with description("Creating an Email"):
                 # Python 2.7 compat
                 check_str = unicode(check_str)
             e.add_attachment(input_buff=input_iostr, attname=f_name)
-            for filename, filecontent in e.attachments:
+            for attachment in e.attachments:
+                filename = attachment['name']
+                filecontent = attachment['content']
                 expect(filecontent).to(equal(check_str))
 
         with it('must add a base64 string as attachment to body'):
@@ -321,7 +325,9 @@ with description("Creating an Email"):
                 # Python 2.7 compat
                 base64_str = unicode(base64_str)
             e.add_attachment(input_b64=base64_str, attname=f_name)
-            for filename, filecontent in e.attachments:
+            for attachment in e.attachments:
+                filename = attachment['name']
+                filecontent = attachment['content']
                 expect(filecontent).to(equal(base64_str))
 
         with it('must raise an exception adding an unexisting attachment'):


### PR DESCRIPTION
- Fix body text and html getting with correct encoder from PART Header
- Fix attachment name getting when more than one header on attachment PART
- Fix attachment getting when not using APPLICATION PART
- Improve attachments property with dict return, specifying the elemts returned:
  - PART Type
  - Filename
  - File content