### PR TITLE
ADD Address Improvements

### DIFF
--- a/qreu/address.py
+++ b/qreu/address.py
@@ -8,7 +8,14 @@ except ImportError:
 from email.utils import getaddresses, parseaddr
 
 
-Address = namedtuple('Address', ['display_name', 'address'])
+BaseAddress = namedtuple('Address', ['display_name', 'address'])
+
+class Address(BaseAddress):
+    @property
+    def display(self):
+        if self.display_name:
+            return '{display_name} <{address}>'.format(**self._asdict())
+        return self.address
 
 
 def parse(header):

--- a/qreu/address.py
+++ b/qreu/address.py
@@ -17,6 +17,10 @@ class Address(BaseAddress):
             return '{display_name} <{address}>'.format(**self._asdict())
         return self.address
 
+    @staticmethod
+    def parse(header):
+        return parse(header)
+
 
 def parse(header):
     """Parse email string using `parseaddr`

--- a/spec/address_spec.py
+++ b/spec/address_spec.py
@@ -10,11 +10,18 @@ with description('address module'):
             expect(r).to(have_property('address', 'user@example.com'))
             expect(r).to(have_property('display_name', 'Firstname Secondname'))
 
+        with it('must have a display propery with a formatted address'):
+            addr_str = 'Firstname Secondname <user@example.com>'
+            r = parse(addr_str)
+            expect(r).to(have_property('display', addr_str))
+            addr_str = 'user@example.com'
+            r = parse(addr_str)
+            expect(r).to(have_property('display', addr_str))
+
         with it('must parse multiple addresses'):
             r = parse_list('First <f@example.com>, Second <s@example.com>')
             expect(r).to(be_a(AddressList))
             expect(r).to(have_property('addresses', ['f@example.com', 's@example.com']))
-
 
         with it('can sum AddressList'):
             a1 = AddressList(['User <u@example.com>'])

--- a/spec/address_spec.py
+++ b/spec/address_spec.py
@@ -1,4 +1,4 @@
-from qreu.address import parse, parse_list, AddressList
+from qreu.address import parse, parse_list, AddressList, Address
 
 from expects import *
 
@@ -10,13 +10,18 @@ with description('address module'):
             expect(r).to(have_property('address', 'user@example.com'))
             expect(r).to(have_property('display_name', 'Firstname Secondname'))
 
-        with it('must have a display propery with a formatted address'):
+        with it('must have a display with a formatted address as on creation'):
             addr_str = 'Firstname Secondname <user@example.com>'
             r = parse(addr_str)
             expect(r).to(have_property('display', addr_str))
             addr_str = 'user@example.com'
             r = parse(addr_str)
             expect(r).to(have_property('display', addr_str))
+
+        with it('must be able to parse from the class Adress'):
+            addr_str = 'Firstname Secondname <user@example.com>'
+            r = parse(addr_str)
+            expect(r).to(equal(Address.parse(addr_str)))
 
         with it('must parse multiple addresses'):
             r = parse_list('First <f@example.com>, Second <s@example.com>')


### PR DESCRIPTION
- "BaseAddress" would work as basic NamedTuple obj
- New "Address" should work as basic NamedTuple plus the following features:
  - New property "`display`" that works as a reverse of the "`parse`" method
  - New "`parse`" method