### PR TITLE
Fix attachment header getting

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -433,7 +433,7 @@ class Email(object):
             # Get Attachments
             else:
                 files = return_vals.get('files', [])
-                new_attach = part.get('Content-Disposition', False)
+                new_attach = part.get('Content-Disposition', [])
                 if 'filename' in new_attach:
                     filename = [
                          f for f in new_attach.split(';') if 'filename=' in f
@@ -453,7 +453,7 @@ class Email(object):
         """
         for part in self.email.walk():
             if not part.get_content_maintype() in ['multipart', 'text']:
-                new_attach = part.get('Content-Disposition', False)
+                new_attach = part.get('Content-Disposition', [])
                 if 'filename' in new_attach:
                     if 'filename' in new_attach:
                         filename = [


### PR DESCRIPTION
Solves a bug when parsing the email for attachments.

If the part was not multipart or text but it wasn't an attachment, or a correctly headed one, an exception was being thrown (`ValueError: Bool is not iterable`)

If the part does not have the "`Content-Disposition`" header, we'll ignore it.

## Todo

- [x] Fix bug
- [ ] Improve the tests to catch the bug