### PR TITLE
ADD SSL atribute from SMTP sendcontext

### DIFF
--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -57,9 +57,28 @@ class FileSender(Sender):
 
 class SMTPSender(Sender):
     def __init__(
-            self, host='localhost', port=0, user=None, passwd=None,
+            self, host='localhost', port=25, user=None, passwd=None,
             ssl_keyfile=None, ssl_certfile=None, tls=False, ssl=False
     ):
+        """
+        Sender context to send through SMTP
+        :param host:            Host to the SMTP Server
+        :type host:             str
+        :param port:            Port for the SMTP Connection (Default is 25)
+        :type port:             int
+        :param user:            User for the SMTP Connection Login
+        :type user:             str
+        :param passwd:          Password for the SMTP Connection Login
+        :type passwd:           str
+        :param ssl_keyfile:     Path to the SSL keyfile (TLS Connection)
+        :type ssl_keyfile:      str
+        :param ssl_certfile:    Path to the SSL certfile (TLS Connection)
+        :type ssl_certfile:     str
+        :param tls:             Start TLS after basic SMTP connection
+        :type tls:              boolean
+        :param ssl:             Start connection as SMTP-SSL
+        :type ssl:              boolean
+        """
         super(SMTPSender, self).__init__(
             _host=host, _port=port,
             _user=user, _passwd=passwd,

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -96,7 +96,6 @@ with description('Senders'):
                     530, "5.7.0 Must issue a STARTTLS command first.")
                 with patch('qreu.sendcontext.SMTP_SSL') as msmtp_ssl:
                     smtp_mocked = Mock()
-                    smtp_mocked.login.return_value = True
                     smtp_mocked.starttls.return_value = True
                     smtp_mocked.login.return_value = True
                     smtp_mocked.send.return_value = True
@@ -111,6 +110,24 @@ with description('Senders'):
                             ssl_certfile='ssl_certfile'
                     ) as sender:
                         expect(sender.send(self.test_mail)).to(be_true)
+
+        with it('must try SMTP_SSL connection if SSL is enabled'):
+            with patch('qreu.sendcontext.SMTP_SSL') as msmtp_ssl:
+                smtp_mocked = Mock()
+                smtp_mocked.login.return_value = True
+                smtp_mocked.send.return_value = True
+                smtp_mocked.sendmail.return_value = True
+                smtp_mocked.close.return_value = True
+                msmtp_ssl.return_value = smtp_mocked
+                with SMTPSender(
+                        host='host',
+                        user='user',
+                        passwd='passwd',
+                        ssl_keyfile='ssl_keyfile',
+                        ssl_certfile='ssl_certfile',
+                        ssl=True
+                ) as sender:
+                    expect(sender.send(self.test_mail)).to(be_true)
 
         with it('must raise exception after Failure if no TLS is enabled'):
             def call_wrongly():


### PR DESCRIPTION
## PRE

According to SMTP Protocol and [SMTPLib](https://docs.python.org/2/library/smtplib.html) package, there are 3 ways of authenticating:

- Insecure (usually port 25), using `SMTP()`
- Insecure becoming secure (usually port 587), using `SMTP()` and then `starttls`
  - This method uses the port 25 for the `ehlo` request and then starts a secure connection on port 587 using TLS.
- Secure (usually port 465), using `SMTP_SSL()`

After connection, login requests are optional, and if TLS/SSL they are usually required.

More info about the TLS/SSL issue: https://www.fastmail.com/help/technical/ssltlsstarttls.html

## Issue

We only manage if we have to become a TLS connection and we only start the SSL connection after a failure of basic SMTP connection on port 485.

If the port 25 is filtered, it may wait for timeout and then retry with the SMTP_SSL.

## Solution

Adding a `ssl` attribute on the `SMTPSenderContext`, we start the `SMTP_SSL` connection without the exception workaround.