### PR TITLE
'\n' on Base64

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -297,10 +297,8 @@ class Email(object):
                 input_buff.read().encode('utf-8'))
         else:
             if '\n' not in str(input_b64):
-                input_b64 = '\n'.join(
-                    input_b64[pos:pos + 76]
-                    for pos in xrange(0, len(input_b64), 76)
-                ) + '\n'
+                input_b64 = base64.decodestring(input_b64)
+                input_b64 = base64.encodestring(input_b64)
             attachment_str = input_b64
 
         attachment = MIMEApplication('', _subtype='octet-stream')

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -296,6 +296,11 @@ class Email(object):
             attachment_str = base64.encodestring(
                 input_buff.read().encode('utf-8'))
         else:
+            if '\n' not in input_b64:
+                input_b64 = '\n'.join(
+                    input_b64[pos:pos + 76]
+                    for pos in xrange(0, len(input_b64), 76)
+                ) + '\n'
             attachment_str = input_b64
 
         attachment = MIMEApplication('', _subtype='octet-stream')

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -270,7 +270,7 @@ class Email(object):
         self.email.attach(msg_part)
         return True
 
-    def add_attachment(self, input_buff=False, attname=False):
+    def add_attachment(self, input_buff, attname=False):
         """
         Add an attachment file to the email
         :param input_buff:  Buffer of the file to attach (something to read)
@@ -280,8 +280,7 @@ class Email(object):
         :return:           True if Added, Exception if failed
         :rtype:            bool
         """
-        if not input_buff:
-            raise ValueError('Attachment not provided!')
+
         try:
             # Try to get name from input if not provided
             filename = attname or input_buff.name
@@ -290,11 +289,7 @@ class Email(object):
         from os.path import basename
         import base64
 
-        if input_buff:
-            attachment_str = base64.encodestring(
-                input_buff.read().encode('utf-8'))
-        else:
-            attachment_str = ''
+        attachment_str = base64.encodestring(input_buff.read().encode('utf-8'))
 
         attachment = MIMEApplication('', _subtype='octet-stream')
         attachment.set_charset('utf-8')

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -270,19 +270,17 @@ class Email(object):
         self.email.attach(msg_part)
         return True
 
-    def add_attachment(self, input_buff=False, input_b64=False, attname=False):
+    def add_attachment(self, input_buff=False, attname=False):
         """
         Add an attachment file to the email
         :param input_buff:  Buffer of the file to attach (something to read)
         :type input_buff:   Buffer
-        :param input_b64:  Base64-based string to attach as file
-        :type input_b64:   str or bytes
         :param attname:    Name of the attachment
         :type attname:     str
         :return:           True if Added, Exception if failed
         :rtype:            bool
         """
-        if not (input_buff or input_b64):
+        if not input_buff:
             raise ValueError('Attachment not provided!')
         try:
             # Try to get name from input if not provided
@@ -296,10 +294,7 @@ class Email(object):
             attachment_str = base64.encodestring(
                 input_buff.read().encode('utf-8'))
         else:
-            if '\n' not in str(input_b64):
-                input_b64 = base64.decodestring(input_b64)
-                input_b64 = base64.encodestring(input_b64)
-            attachment_str = input_b64
+            attachment_str = ''
 
         attachment = MIMEApplication('', _subtype='octet-stream')
         attachment.set_charset('utf-8')

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -296,7 +296,7 @@ class Email(object):
             attachment_str = base64.encodestring(
                 input_buff.read().encode('utf-8'))
         else:
-            if '\n' not in input_b64:
+            if '\n' not in str(input_b64):
                 input_b64 = '\n'.join(
                     input_b64[pos:pos + 76]
                     for pos in xrange(0, len(input_b64), 76)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-mamba
+mamba==0.9.3
 expects
 mock

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='qreu',
-    version='0.7.2',
+    version='0.7.3',
     packages=find_packages(),
     url='https://github.com/gisce/qreu',
     install_requires=[

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -333,24 +333,6 @@ with description("Creating an Email"):
 
             expect(call_wrongly).to(raise_error(ValueError))
 
-        with it('must add an attachments with b64'):
-            import base64
-
-            e = Email()
-            f_path = 'spec/fixtures/0.txt'
-            f_name = str('0.txt')
-            with open(f_path, 'r') as ffile:
-                text = ffile.read()
-
-            with open(f_path, 'r') as ffile:
-                e.add_attachment(input_buff=ffile, attname=f_name)
-
-            encoded_text = base64.encodestring(text.encode('utf-8'))
-
-            for attachment in e.attachments:
-                filecontent = attachment['content']
-                expect(filecontent).to(equal(encoded_text.decode('utf-8')))
-
     with context("using kwargs"):
         with before.all:
             self.vals = {

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -361,7 +361,7 @@ with description("Creating an Email"):
             f_name = '0.txt'
             with open(f_path, 'r') as ffile:
                 text = ffile.read().strip()
-            encoded_text = base64.encodestring(text)
+            encoded_text = base64.encodestring(text.encode('utf-8'))
             e.add_attachment(input_b64=encoded_text, attname=f_name)
 
             for attachment in e.attachments:

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -353,6 +353,29 @@ with description("Creating an Email"):
 
             expect(call_wrongly).to(raise_error(ValueError))
 
+        with it('must add an attachments with b64'):
+            import base64
+
+            e = Email()
+            f_path = 'spec/fixtures/0.txt'
+            f_name = '0.txt'
+            with open('f_path', 'r') as ffile:
+                text = ffile.read().strip()
+            encoded_text = base64.encodestring(text)
+            e.add_attachment(encoded_text)
+
+            for attachment in e.attachments:
+                filecontent = attachment['content']
+                expect(filecontent).to(equal(encoded_text))
+            del e
+            e = Email()
+            not_ns = encoded_text.replace('\n', '')
+            e.add_attachment(not_ns)
+
+            for attachment in e.attachments:
+                filecontent = attachment['content']
+                expect(filecontent).to(equal(encoded_text))
+
     with context("using kwargs"):
         with before.all:
             self.vals = {

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -366,15 +366,15 @@ with description("Creating an Email"):
 
             for attachment in e.attachments:
                 filecontent = attachment['content']
-                expect(filecontent).to(equal(encoded_text))
+                expect(filecontent).to(equal(encoded_text.decode('utf-8')))
             del e
             e = Email()
-            not_ns = encoded_text.replace('\n', '')
+            not_ns = encoded_text.replace(b'\n', b'')
             e.add_attachment(input_b64=not_ns, attname=f_name)
 
             for attachment in e.attachments:
                 filecontent = attachment['content']
-                expect(filecontent).to(equal(encoded_text))
+                expect(filecontent).to(equal(encoded_text.decode('utf-8')))
 
     with context("using kwargs"):
         with before.all:

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -359,10 +359,10 @@ with description("Creating an Email"):
             e = Email()
             f_path = 'spec/fixtures/0.txt'
             f_name = '0.txt'
-            with open('f_path', 'r') as ffile:
+            with open(f_path, 'r') as ffile:
                 text = ffile.read().strip()
             encoded_text = base64.encodestring(text)
-            e.add_attachment(encoded_text)
+            e.add_attachment(input_b64=encoded_text, attname=f_name)
 
             for attachment in e.attachments:
                 filecontent = attachment['content']
@@ -370,7 +370,7 @@ with description("Creating an Email"):
             del e
             e = Email()
             not_ns = encoded_text.replace('\n', '')
-            e.add_attachment(not_ns)
+            e.add_attachment(input_b64=not_ns, attname=f_name)
 
             for attachment in e.attachments:
                 filecontent = attachment['content']

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -316,26 +316,6 @@ with description("Creating an Email"):
                 filecontent = attachment['content']
                 expect(filecontent).to(equal(check_str))
 
-        with it('must add a base64 string as attachment to body'):
-            import base64
-            from io import StringIO
-            e = Email()
-            f_path = 'spec/fixtures/0.txt'
-            f_name = '0.txt'
-            with open(f_path) as f:
-                f_data = f.read()
-            base64_str = base64.encodestring(f_data.encode('utf-8'))
-            try:
-                base64_str = str(base64_str, 'utf-8')
-            except TypeError:
-                # Python 2.7 compat
-                base64_str = unicode(base64_str)
-            e.add_attachment(input_b64=base64_str, attname=f_name)
-            for attachment in e.attachments:
-                filename = attachment['name']
-                filecontent = attachment['content']
-                expect(filecontent).to(equal(base64_str))
-
         with it('must raise an exception adding an unexisting attachment'):
             def call_wrongly():
                 e = Email()
@@ -358,19 +338,14 @@ with description("Creating an Email"):
 
             e = Email()
             f_path = 'spec/fixtures/0.txt'
-            f_name = '0.txt'
+            f_name = str('0.txt')
             with open(f_path, 'r') as ffile:
-                text = ffile.read().strip()
-            encoded_text = base64.encodestring(text.encode('utf-8'))
-            e.add_attachment(input_b64=encoded_text, attname=f_name)
+                text = ffile.read()
 
-            for attachment in e.attachments:
-                filecontent = attachment['content']
-                expect(filecontent).to(equal(encoded_text.decode('utf-8')))
-            del e
-            e = Email()
-            not_ns = encoded_text.replace(b'\n', b'')
-            e.add_attachment(input_b64=not_ns, attname=f_name)
+            with open(f_path, 'r') as ffile:
+                e.add_attachment(input_buff=ffile, attname=f_name)
+
+            encoded_text = base64.encodestring(text.encode('utf-8'))
 
             for attachment in e.attachments:
                 filecontent = attachment['content']


### PR DESCRIPTION
Adds '\n' if base64 attachment does not have it.

Before the attachments never had the '\n' if they were not encoded on this library.