### PR TITLE
Add support for fowarding mails

### DIFF
--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, unicode_literals
-from qreu import Email
+from qreu import Email, address
 from qreu.address import AddressList, Address
 from qreu.sendcontext import Sender
 from datetime import datetime, tzinfo, timedelta
@@ -421,3 +421,41 @@ with description("Creating an Email"):
             expect(e.header('Date')).to_not(be_false)
             expect(e.add_header('Date', e.header('Date'))).to(be_false)
             expect(len(e.mime_string.split('Date'))).to(equal(2))
+
+
+with description('Forwarding an email'):
+
+    with before.each as self:
+        with open('spec/fixtures/1.txt', 'r') as f:
+            self.m = Email.parse(f.read())
+
+        self.mf = self.m.forward(**{
+            'from': 'From User <from@example.com>',
+            'to': 'To User <to@example.com>'
+        })
+
+    with it("must get from and to"):
+        mf = self.mf
+        expect(mf.to.addresses).to(equal(['to@example.com']))
+        expect(mf.from_).to(equal(address.parse('From User <from@example.com>')))
+
+    with it('must clean cc and bcc'):
+        mf = self.mf
+        expect(mf.cc).to(be_empty)
+        expect(mf.bcc).to(be_empty)
+
+    with it('must add itself to references'):
+        m = self.m
+        mf = self.mf
+        references = m.references + [m.header('Message-ID')]
+        expect(mf.references).to(contain_exactly(*references))
+
+    with it('must have a new message-id'):
+        m = self.m
+        mf = self.mf
+        expect(mf.header('Message-ID')).not_to(equal(m.header('Message-ID')))
+
+    with it('must rewrite subject with forward prefix'):
+        mf = self.mf
+        expect(mf.is_forwarded).to(be_true)
+        expect(mf.header('Subject').startswith('Fwd:')).to(be_true)

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from qreu import Email, address
 from qreu.address import AddressList, Address
 from qreu.sendcontext import Sender
+from qreu.email import get_body_html
 from datetime import datetime, tzinfo, timedelta
 from mock import patch
 import qreu.address
@@ -459,3 +460,24 @@ with description('Forwarding an email'):
         mf = self.mf
         expect(mf.is_forwarded).to(be_true)
         expect(mf.header('Subject').startswith('Fwd:')).to(be_true)
+
+
+with description('Parsing HTML'):
+    with it('should return the body'):
+        html = """<html><head><title>Foo</title></head><body><p>This is the <strong>body</strong>!</p></body></html>"""
+        expect(get_body_html(html)).to(equal("<p>This is the <strong>body</strong>!</p>"))
+    with context('if orignal html has new lines'):
+        with it('should return the body too'):
+            html = """<html>
+                        <head>
+                           <title>Foo</title>
+                        </head>
+                        <body>
+                          <p>This is the <strong>body</strong>!</p>
+                        </body>
+                      </html>"""
+            expect(get_body_html(html)).to(equal("<p>This is the <strong>body</strong>!</p>"))
+    with context('if there is no body'):
+        with it('should return the complete text'):
+            html = "<p>This is the <strong>body</strong>!</p>"
+            expect(get_body_html(html)).to(equal("<p>This is the <strong>body</strong>!</p>"))


### PR DESCRIPTION
Add support to forward an email as:

```python

orignal_mail  # This is an object of qreu.email.Email
forward_mail = orignal_mail.forward(**{
    'to': 'User <user@example.com>',
    'from': 'Me <me@example.com>'
    'body_html': '<h1>Forward Mail!</h1><br><p>Original email</p><div>{original}</div>'
})
```

And if we are in a `SenderContext` we can send it

```python
forward_mail.send()
```