### PR TITLE
Fix decode header

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -235,12 +235,13 @@ class Email(object):
         if header_value:
             for part in decode_header(header_value):
                 if part[1]:
-                    result.append(part[0].decode(part[1]))
+                    encoded = part[0].decode(part[1])
                 elif isinstance(part[0], bytes):
-                    result.append(part[0].decode('utf-8'))
+                    encoded = part[0].decode('utf-8')
                 else:
-                    result.append(part[0])
-            header_value = ''.join(result)
+                    encoded = part[0]
+                result.append(encoded.strip())
+            header_value = ' '.join(result)
 
         return header_value
 
@@ -301,12 +302,13 @@ class Email(object):
             result = []
             for part in decode_header(header_value):
                 if part[1]:
-                    result.append(part[0].decode(part[1]))
+                    encoded = part[0].decode(part[1])
                 elif isinstance(part[0], bytes):
-                    result.append(part[0].decode('utf-8'))
+                    encoded = part[0].decode('utf-8')
                 else:
-                    result.append(part[0])
-            header_value = ''.join(result)
+                    encoded = part[0]
+                result.append(encoded.strip())
+            header_value = ' '.join(result)
             self.bccs = header_value
         else:
             self.email[header] = header_value

--- a/spec/address_spec.py
+++ b/spec/address_spec.py
@@ -1,5 +1,5 @@
+# coding=utf-8
 from qreu.address import parse, parse_list, AddressList, Address
-
 from expects import *
 
 

--- a/spec/fixtures/5.txt
+++ b/spec/fixtures/5.txt
@@ -1,0 +1,1 @@
+From: =?utf-8?Q?M=C3=B3nica=20de=20Test=20Example?= <monica@example.com>

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -20,7 +20,7 @@ from six import PY2
 with description('Parsing an Email'):
     with before.all:
         self.raw_messages = []
-        for fixture in range(0, 5):
+        for fixture in range(0, 6):
             with open('spec/fixtures/{0}.txt'.format(fixture)) as f:
                 self.raw_messages.append(f.read())
 
@@ -108,6 +108,10 @@ with description('Parsing an Email'):
         attch = [p['name'] for p in c.attachments]
         expect(attch).to(contain_exactly('image.png'))
         expect(c.body_parts['files']).to(contain_exactly('image.png'))
+
+    with it('should parse correctly address from weird header'):
+        c = Email.parse(self.raw_messages[5])
+        expect(c.from_).to(have_property('address', 'monica@example.com'))
 
 with description("Creating an Email"):
     with context("empty"):
@@ -390,7 +394,7 @@ with description("Creating an Email"):
 
         with it('must add addresses correctly as "name" <address>'):
             address = 'spécial <special@example.com>'
-            parsed = 'spécial<special@example.com>'
+            parsed  = 'spécial <special@example.com>'
             e = Email(to=address)
             expect(e.to).to(equal([parsed]))
             e = Email(cc=address)

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding=utf-8
 from __future__ import absolute_import, unicode_literals
 from mamba import *
 from expects import *


### PR DESCRIPTION
This is a little weird fix because have a different behavior in python2 and python3:

This header:
`From: =?utf-8?Q?M=C3=B3nica=20de=20Test=20Example?= <monica@example.com>`

in python2 will be decoded as:

```python
>>> from email.header import decode_header
>>> decode_header("From: =?utf-8?Q?M=C3=B3nica=20de=20Test=20Example?= <monica@example.com>")
[('From:', None), ('M\xc3\xb3nica de Test Example', 'utf-8'), ('<monica@example.com>', None)]
```

in python3 will be decoded as:

```python
>>> from email.header import decode_header
>>> decode_header("From: =?utf-8?Q?M=C3=B3nica=20de=20Test=20Example?= <monica@example.com>")
[(b'From: ', None), (b'M\xc3\xb3nica de Test Example', 'utf-8'), (b' <monica@example.com>', None)]
```

**:fire: Note de difference bettween the first space ` `  in the address in py2 and py3**

 