### PR TITLE
Avoid repeat Content-Transfer-Encoding

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -385,14 +385,13 @@ class Email(object):
         if filetype:
             splitedfiletype = filetype.split('/')[-1]
             subtype = splitedfiletype
-        attachment = MIMEApplication('', _subtype=subtype)
+        attachment = MIMEApplication('', _subtype=subtype, _encoder=email.encoders.encode_base64)
 
         attachment.set_charset('utf-8')
         attachment.add_header(
             'Content-Disposition',
             'attachment; filename="%s"' % self.remove_accent(u'{}'.format(basename(filename)))
         )
-        attachment.add_header('Content-Transfer-Encoding', 'base64')
         attachment.set_payload(
             attachment_str,
             charset=attachment.get_charset()


### PR DESCRIPTION
We noticed that the shared inbox e-mail client we are using has trouble with some repeated headers of the attachment.

In particular it has trouble with the "Content-Transfer-Encoding" header. Qreu sends it two times like this:

```
--===============6391006585805361748==
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Type: application/pdf; charset="utf-8"
Content-Disposition: attachment; filename="file.pdf"
Content-Transfer-Encoding: base64

JVBERi0xLjQKMSAwIG9iago8P...
```

By default when you create the attachment as a `MIMEApplication` the Content-Transfer-Encoding header is added by default and also by default is base64, so the `Content-Transfer-Encoding` doesn't have to be added manually afterwards.

But, because "Explicit is better than implicit" in this Pull Request I have hardcoded the _encoder to base64 so the change is more clear for the reviewer.

The result with the new changes are:

```
--===============5362653904239654853==
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Type: application/pdf; charset="utf-8"
Content-Disposition: attachment; filename="file.pdf"

JVBERi0xLjQKMSAwIG9iago8P...
```