### PR TITLE
Same behaviour in py2 and py3

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -375,7 +375,7 @@ class Email(object):
 
         # Read bytes from buffer
         content = input_buff.getvalue() if isinstance(input_buff, (StringIO, BytesIO)) else input_buff.read()
-        if isinstance(content, six.text_type):  # Python 2
+        if isinstance(content, six.text_type):  # Check for text/unicode type in both Python 2 and 3
             content = content.encode('utf-8')
 
         # Base64 encode

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -288,16 +288,9 @@ with description("Creating an Email"):
             expect(files).to(equal([f_name, f_name]))
             for attachment in e.attachments:
                 filename = attachment['name']
-                filecontent = attachment['content']
+                filecontent = attachment['content'].decode('utf-8')
                 with open(f_path, 'rb') as f:
-                    # attachment_str = base64.encodestring(f.read())
                     attachment_str = f.read().decode('utf-8')
-                    # try:
-                    #     attachment_str = str(attachment_str, 'utf-8')
-                    # except TypeError as e:
-                    #     print(e)
-                    #     # Python 2.7 compat
-                    #     attachment_str = unicode(attachment_str)
                 expect(filecontent).to(equal(attachment_str))
 
         with it('must add an iostring as attachment to body'):
@@ -311,16 +304,10 @@ with description("Creating an Email"):
 
             input_iostr = BytesIO(f_data)
             check_str = f_data.decode('utf-8')
-            # check_str = base64.encodestring(f_data)
-            # try:
-            #     check_str = str(check_str, 'utf-8')
-            # except TypeError:
-            #     # Python 2.7 compat
-            #     check_str = unicode(check_str)
             e.add_attachment(input_buff=input_iostr, attname=f_name)
             for attachment in e.attachments:
                 filename = attachment['name']
-                filecontent = attachment['content']
+                filecontent = attachment['content'].decode('utf-8')
                 expect(filecontent).to(equal(check_str))
 
         with it('must raise an exception adding an unexisting attachment'):


### PR DESCRIPTION
This pull request refactors the email attachment handling in `qreu/email.py` to improve MIME type handling, base64 encoding, and payload decoding. It also updates the corresponding tests in `spec/qreu_spec.py` to align with the changes. The most important changes include restructuring the `add_attachment` method, fixing payload decoding in the `attachments` method, and cleaning up the test cases.

### Refactoring in `qreu/email.py`:

* **Improved MIME type handling and base64 encoding in `add_attachment`:**
  - Refactored the method to use `base64.b64encode` for encoding and `mimetypes.guess_type` for determining the MIME type.
  - Simplified the creation of the MIME part and removed unnecessary charset settings.

* **Fixed payload decoding in `attachments`:**
  - Updated `get_payload` to decode the content automatically by passing `decode=True`.

### Updates in `spec/qreu_spec.py`:

* **Test updates for attachment content decoding:**
  - Modified tests to decode attachment content using `.decode('utf-8')` for comparison with expected values. [[1]](diffhunk://#diff-d295afbf71cb40a1dd2b44b9f86ccffb4c8d7808fe9fd173e71089118bab22b2L291-L300) [[2]](diffhunk://#diff-d295afbf71cb40a1dd2b44b9f86ccffb4c8d7808fe9fd173e71089118bab22b2L314-R310)

* **Removed outdated and commented code:**
  - Cleaned up legacy Python 2 compatibility code and unused commented lines in test cases.