### PR TITLE
Fix parsing from address with special chars

### DIFF
--- a/qreu/address.py
+++ b/qreu/address.py
@@ -69,7 +69,9 @@ def normalize_display_address(addr_string):
         email = addr_part.strip('> ').strip()
 
         if name and not (name.startswith('"') and name.endswith('"')):
-            name = '"{}"'.format(name)
+            name = name.replace('"', r'\"')
+            if any(c in name for c in [',', ';', ':']):
+                name = '"{}"'.format(name)
 
         return '{} <{}>'.format(name, email)
     return addr_string  # If no angle brackets found, return as-is

--- a/qreu/address.py
+++ b/qreu/address.py
@@ -1,6 +1,10 @@
-from __future__ import absolute_import
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
 
 from collections import namedtuple
+
+import six
+
 try:
     from collections import UserList
 except ImportError:
@@ -45,3 +49,28 @@ class AddressList(UserList):
     @property
     def addresses(self):
       return [x[1] for x in getaddresses(self.data) if x[1]]
+
+
+def normalize_display_address(addr_string):
+    """
+    Ensures that the display name in an email address is properly quoted
+    if it contains special characters. If a display name is present before
+    a '<...>' address block and is not already quoted, it will be quoted.
+
+    :param addr_string: A string containing a full email address
+                        (e.g. RAMOS ESCOLÀ, PEPITA <pepita@example.com>)
+    :return: A normalized email string with quoted display name if needed
+    """
+    if isinstance(addr_string, six.binary_type):
+        addr_string = addr_string.decode('utf-8')
+    if '<' in addr_string and '>' in addr_string:
+        name_part, addr_part = addr_string.split('<', 1)
+        name = name_part.strip()
+        email = addr_part.strip('> ').strip()
+
+        if name and not (name.startswith('"') and name.endswith('"')):
+            name = '"{}"'.format(name)
+
+        return '{} <{}>'.format(name, email)
+    return addr_string  # If no angle brackets found, return as-is
+

--- a/qreu/address.py
+++ b/qreu/address.py
@@ -68,7 +68,8 @@ def normalize_display_address(addr_string):
         name = name_part.strip()
         email = addr_part.strip('> ').strip()
 
-        if name and not (name.startswith('"') and name.endswith('"')):
+        special_chars = {',', ';', '<', '>'}
+        if name and not (name.startswith('"') and name.endswith('"')) and any(char in name for char in special_chars):
             name = name.replace('"', r'\"')
             if any(c in name for c in [',', ';', ':']):
                 name = '"{}"'.format(name)

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -466,7 +466,9 @@ class Email(object):
 
         :return: `address.Address`
         """
-        return address.parse(self.header('From', ''))
+        return address.parse(address.normalize_display_address(
+            self.header('From', ''))
+        )
 
     @property
     def to(self):

--- a/spec/address_spec.py
+++ b/spec/address_spec.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from qreu.address import parse, parse_list, AddressList, Address
+from qreu.address import parse, parse_list, AddressList, Address, normalize_display_address
 from expects import *
 
 
@@ -38,3 +38,29 @@ with description('address module'):
             expect((a1 + a2).addresses).to(contain_exactly(
                 'u@example.com', 'u2@example.com'
             ))
+
+with context('normalizing address display name'):
+    with it('must quote display name if it contains commas'):
+        addr_str = 'RAMOS ESCOLÀ, PEPITA <pepita@example.com>'
+        normalized = normalize_display_address(addr_str)
+        expect(normalized).to(equal(u'"RAMOS ESCOLÀ, PEPITA" <pepita@example.com>'))
+
+    with it('must not quote display name if already quoted'):
+        addr_str = u'"RAMOS ESCOLÀ, PEPITA" <pepita@example.com>'
+        normalized = normalize_display_address(addr_str)
+        expect(normalized).to(equal(addr_str))
+
+    with it('must not alter address without display name'):
+        addr_str = 'pepita@example.com'
+        normalized = normalize_display_address(addr_str)
+        expect(normalized).to(equal(addr_str))
+
+    with it('must quote display name with semicolon'):
+        addr_str = 'Admin; Name <admin@example.com>'
+        normalized = normalize_display_address(addr_str)
+        expect(normalized).to(equal('"Admin; Name" <admin@example.com>'))
+
+    with it('must ignore address without angle brackets'):
+        addr_str = 'Admin Name admin@example.com'
+        normalized = normalize_display_address(addr_str)
+        expect(normalized).to(equal(addr_str))

--- a/spec/address_spec.py
+++ b/spec/address_spec.py
@@ -64,3 +64,9 @@ with context('normalizing address display name'):
         addr_str = 'Admin Name admin@example.com'
         normalized = normalize_display_address(addr_str)
         expect(normalized).to(equal(addr_str))
+
+    with it('must escape internal quotes if present'):
+        addr_str = 'SAYS "YES", PEPITA <pepita@example.com>'
+        expect(normalize_display_address(addr_str)).to(equal(
+            u'"SAYS \\"YES\\", PEPITA" <pepita@example.com>'
+        ))

--- a/spec/fixtures/7.txt
+++ b/spec/fixtures/7.txt
@@ -1,0 +1,3 @@
+From: "RAMOS ESCOLÀ, PEPITA" <pepitaramos@example.com>
+To: SAC <sac@example.com>
+CC: "Bústia General" <general@example.com>

--- a/spec/fixtures/8.txt
+++ b/spec/fixtures/8.txt
@@ -1,0 +1,1 @@
+From: =?iso-8859-1?Q?RAMOS_ESCOL=C0=2C_PEPITA?= <pepita@example.com>

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -19,7 +19,7 @@ from six import PY2
 with description('Parsing an Email'):
     with before.all:
         self.raw_messages = []
-        for fixture in range(0, 7):
+        for fixture in range(0, 9):
             with open('spec/fixtures/{0}.txt'.format(fixture)) as f:
                 self.raw_messages.append(f.read())
 
@@ -115,6 +115,17 @@ with description('Parsing an Email'):
     with it('should parse correctly address from weird header'):
         c = Email.parse(self.raw_messages[5])
         expect(c.from_).to(have_property('address', 'monica@example.com'))
+        expect(c.from_).to(have_property('display_name', u'Mónica de Test Example'))
+
+        c = Email.parse(self.raw_messages[8])
+        expect(c.from_).to(have_property('address', 'pepita@example.com'))
+        expect(c.from_).to(have_property('display_name', u'RAMOS ESCOLÀ, PEPITA'))
+
+    with it('should parse correctly address with accents'):
+        c = Email.parse(self.raw_messages[7])
+        expect(c.from_).to(have_property('display_name', u'RAMOS ESCOLÀ, PEPITA'))
+        expect(c.from_.address).to(equal('pepitaramos@example.com'))
+        expect(c.cc.addresses).to(contain_exactly(u'general@example.com'))
 
 with description("Creating an Email"):
     with context("empty"):


### PR DESCRIPTION
This pull request introduces a new utility function, `normalize_display_address`, to handle email address normalization, ensuring display names are properly quoted when necessary. It also updates the `from_` method in the `Email` class to use this normalization function, adds corresponding test cases, and includes new fixtures for testing. Below are the key changes:

### New functionality for email address normalization:
* Added the `normalize_display_address` function in `qreu/address.py` to ensure display names in email addresses are quoted if they contain special characters, such as commas or semicolons.
* Updated the `from_` method in `qreu/email.py` to apply the `normalize_display_address` function to the "From" header before parsing.

### Unit tests for normalization:
* Added test cases in `spec/address_spec.py` to validate the behavior of `normalize_display_address`, covering scenarios like unquoted display names, already quoted names, and addresses without display names or angle brackets.
* Updated `spec/qreu_spec.py` to include tests for parsing emails with normalized display names and accented characters.

### Test fixtures:
* Added new email fixtures (`spec/fixtures/7.txt` and `spec/fixtures/8.txt`) to test parsing of display names with accents and encoded characters. [[1]](diffhunk://#diff-95a94436ce9113efbf7aa8d8abb7bb78994cff682639aa81372c0f04c2d415c5R1-R3) [[2]](diffhunk://#diff-d622072345d1f9290e7c9e2dd37ea83319543acf497548643ec779e6e5771f84R1)
* Adjusted the test suite in `spec/qreu_spec.py` to load the new fixtures.