### PR TITLE
Fix poweremail mailbox creation with attatchments

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -540,10 +540,14 @@ class Email(object):
         for part in self.email.walk():
             filename = part.get_filename()
             if filename:
+                # Removed part.get_payload(decode=True)
+                # If we use decode=True content is b64decoded which is a raw content
+                payload = part.get_payload()
+                payload = payload.decode() if isinstance(payload, bytes) else payload
                 yield {
                     'type': part.get_content_type(),
                     'name': filename,
-                    'content': part.get_payload(decode=True)
+                    'content': payload
                 }
 
     @property

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -299,9 +299,9 @@ with description("Creating an Email"):
             expect(files).to(equal([f_name, f_name]))
             for attachment in e.attachments:
                 filename = attachment['name']
-                filecontent = attachment['content'].decode('utf-8')
+                filecontent = attachment['content']
                 with open(f_path, 'rb') as f:
-                    attachment_str = f.read().decode('utf-8')
+                    attachment_str = base64.b64encode(f.read()).decode('utf-8')
                 expect(filecontent).to(equal(attachment_str))
 
         with it('must add an iostring as attachment to body'):
@@ -314,11 +314,11 @@ with description("Creating an Email"):
                 f_data = f.read()
 
             input_iostr = BytesIO(f_data)
-            check_str = f_data.decode('utf-8')
+            check_str = base64.b64encode(f_data).decode('utf-8')
             e.add_attachment(input_buff=input_iostr, attname=f_name)
             for attachment in e.attachments:
                 filename = attachment['name']
-                filecontent = attachment['content'].decode('utf-8')
+                filecontent = attachment['content']
                 expect(filecontent).to(equal(check_str))
 
         with it('must raise an exception adding an unexisting attachment'):


### PR DESCRIPTION
Restored Email.attachments behavior. The content is now returned as base64 unicode since get_payload(decode=True) was returning it as a raw file.

Bug affections: server/bin/addons/poweremail/poweremail_mailbox.py:394
```python
            for attachment_data in mail.attachments:
                # TODO check this
                att_id = attachment_obj.create(cursor, user, {
                    'description': _(
                        "From Poweremail Mailbox {} Original email as {}"
                    ).format(res_id, attachment_data['type']),
                    'datas_fname': attachment_data['name'],
                    'name': attachment_data['name'],
                    'datas': attachment_data['content'],
                    'res_model': self._name,
                    'res_id': res_id
                })
```
