### PR TITLE
Avoid repeat Content-Transfer-Encoding

### DIFF
--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -299,6 +299,10 @@ with description("Creating an Email"):
                 expect(e.add_attachment(input_buff=f)).to(be_true)
             files = [attachment['name'] for attachment in e.attachments]
             expect(files).to(equal([f_name, f_name]))
+            for part in e.email.walk():
+                if part.get_all('Content-Transfer-Encoding'):
+                    expect(len(part.get_all('Content-Transfer-Encoding'))).to(equal(1))
+                    expect(part.get_all('Content-Transfer-Encoding')[0]).to(equal('base64'))
             for attachment in e.attachments:
                 filename = attachment['name']
                 filecontent = attachment['content']


### PR DESCRIPTION
We noticed that the shared inbox e-mail client we are using has trouble with some repeated headers of the attachment.

In particular it has trouble with the "Content-Transfer-Encoding" header. Qreu sends it two times like this:

```
--===============6391006585805361748==
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Type: application/pdf; charset="utf-8"
Content-Disposition: attachment; filename="file.pdf"
Content-Transfer-Encoding: base64

JVBERi0xLjQKMSAwIG9iago8P...
```

By default when you create the attachment as a `MIMEApplication` the Content-Transfer-Encoding header is added by default and also by default is base64, so the `Content-Transfer-Encoding` doesn't have to be added manually afterwards.

But, because "Explicit is better than implicit" in this Pull Request I have hardcoded the _encoder to base64 so the change is more clear for the reviewer.

The result with the new changes are:

```
--===============5362653904239654853==
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Type: application/pdf; charset="utf-8"
Content-Disposition: attachment; filename="file.pdf"

JVBERi0xLjQKMSAwIG9iago8P...
```