### PR TITLE
fer un cast del pass per controlar py2 i py3

### DIFF
--- a/qreu/sendcontext.py
+++ b/qreu/sendcontext.py
@@ -110,7 +110,7 @@ class SMTPSender(Sender):
                 else:
                     raise
         if self._user and self._passwd:
-            self._connection.login(user=self._user, password=self._passwd)
+            self._connection.login(user=self._user, password=str(self._passwd))
         return super(SMTPSender, self).__enter__()
 
     def __exit__(self, etype, evalue, etraceback):

--- a/spec/sendcontext_spec.py
+++ b/spec/sendcontext_spec.py
@@ -142,3 +142,23 @@ with description('Senders'):
                 msmtp.side_effect = SMTPConnectError(
                     530, "5.7.0 Must issue a STARTTLS command first.")
                 expect(call_wrongly).to(raise_error)
+
+        with it('must "send" via smtp the email with SMTPSender'):
+            with patch('qreu.sendcontext.SMTP') as mocked_conn:
+                # Mock the SMTP connection
+                smtp_mocked = Mock()
+                smtp_mocked.login.return_value = True
+                smtp_mocked.starttls.return_value = True
+                smtp_mocked.login.return_value = True
+                smtp_mocked.send.return_value = True
+                smtp_mocked.sendmail.return_value = True
+                smtp_mocked.close.return_value = True
+                mocked_conn.return_value = smtp_mocked
+                with SMTPSender(
+                        host='host',
+                        user='user',
+                        passwd=u'passwd',
+                        ssl_keyfile='ssl_keyfile',
+                        ssl_certfile='ssl_certfile'
+                ) as sender:
+                    sender.send(self.test_mail)


### PR DESCRIPTION
A l'hora de fer la connexió amb el servidor SMTP o SMTPSLL, el codi fa una comprovació on utiliza la contrasenya.

En py2, la password és un unicode, el que provoca que a l'hora de fer aquesta comprovació doni un error, ja que espera un string.

La solució que es pren és fer un cast directe de la password a string i d'aquesta forma ja no dona l'error, ni en py2 ni en py3.

https://github.com/gisce/poweremail/pull/206