### PR TITLE
Fix emails separats per punt i coma

### DIFF
--- a/qreu/address.py
+++ b/qreu/address.py
@@ -9,8 +9,14 @@ try:
     from collections import UserList
 except ImportError:
     from UserList import UserList
-from email.utils import getaddresses, parseaddr
+from email.utils import getaddresses as getaddresses_email, parseaddr
 
+def getaddresses(fieldvalues):
+    """fieldvalues: Iterable[str]"""
+    if isinstance(fieldvalues, six.string_types):
+        fieldvalues = [fieldvalues]
+    fixed_fieldvalues = [x.replace(";", ",") for x in fieldvalues]
+    return getaddresses_email(fixed_fieldvalues)
 
 BaseAddress = namedtuple('Address', ['display_name', 'address'])
 


### PR DESCRIPTION
Si ens arriben emails separats per "punt i coma", es canvia el separador a "coma" abans de passar-ho a la llibreria estàndard de `email` que espera si o si una "coma" com a separador. 


Sense aquests canvis, abans fèiem:

```python

getaddresses(['elteuemail@gisce.net;unaltre@gisce.net']) -> [('', ''), ('', 'elteuemail@gisce.net'), ('', 'unaltre@gisce.net')]
```
<img width="349" height="58" alt="2026-05-21_12-47" src="https://github.com/user-attachments/assets/611cee92-9c43-4f20-8fd6-94fed959d2b6" />


Amb aquests canvis ara fem:
```python
getaddresses(['email@gmail.com;altreemailo@hotmail.com']) -> [('', 'elteuemail@gisce.net'), ('', 'unaltre@gisce.net')]

```
<img width="308" height="48" alt="2026-05-21_12-47_1" src="https://github.com/user-attachments/assets/74b7b5fd-2d77-488e-9659-adbcd4f9669d" />
