### PR TITLE
Add inline attachment support

### DIFF
--- a/qreu/email.py
+++ b/qreu/email.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import email
 import mimetypes
 from email.header import decode_header, Header
-from email.mime.application import MIMEApplication
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate, make_msgid
@@ -353,20 +353,24 @@ class Email(object):
         return unidecode(text)
 
 
-    def add_attachment(self, input_buff, attname=False):
+    def add_attachment(self, input_buff, attname=False, disposition='attachment',
+                       content_id=None):
         """
         Add an attachment file to the email
         :param input_buff:  Buffer of the file to attach (something to read)
         :type input_buff:   Buffer
         :param attname:    Name of the attachment
         :type attname:     str
+        :param disposition: Content-Disposition type
+        :type disposition: str
+        :param content_id: Content-ID header value, without surrounding <>
+        :type content_id:  str
         :return:           True if Added, Exception if failed
         :rtype:            bool
         """
         from os.path import basename
         import base64
         import mimetypes
-        from email.mime.application import MIMEApplication
 
         try:
             filename = attname or input_buff.name
@@ -408,11 +412,16 @@ class Email(object):
             maintype, subtype = filetype.split('/')
 
         # Create MIME part
-        attachment = MIMEApplication('', _subtype=subtype)
+        attachment = MIMEBase(maintype, subtype)
         attachment.add_header(
             'Content-Disposition',
-            'attachment; filename="%s"' % self.remove_accent(u'{}'.format(basename(filename)))
+            '%s; filename="%s"' % (
+                disposition,
+                self.remove_accent(u'{}'.format(basename(filename)))
+            )
         )
+        if content_id:
+            attachment.add_header('Content-ID', '<%s>' % content_id)
         attachment.set_payload(attachment_str)
 
         self.email.attach(attachment)

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -370,7 +370,6 @@ class Email(object):
         """
         from os.path import basename
         import base64
-        import mimetypes
 
         try:
             filename = attname or input_buff.name

--- a/qreu/email.py
+++ b/qreu/email.py
@@ -423,6 +423,7 @@ class Email(object):
         if content_id:
             attachment.add_header('Content-ID', '<%s>' % content_id)
         attachment.set_payload(attachment_str)
+        attachment.add_header('Content-Transfer-Encoding', 'base64')
 
         self.email.attach(attachment)
         return True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='qreu',
-    version='0.16.1',
+    version='0.16.2',
     packages=find_packages(),
     url='https://github.com/gisce/qreu',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='qreu',
-    version='0.16.2',
+    version='0.16.1',
     packages=find_packages(),
     url='https://github.com/gisce/qreu',
     install_requires=[

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -335,6 +335,28 @@ with description("Creating an Email"):
                 filecontent = attachment['content']
                 expect(filecontent).to(equal(check_str))
 
+        with it('must add an inline attachment with content id'):
+            from io import BytesIO
+            e = Email()
+            e.add_attachment(
+                input_buff=BytesIO(b'testContent'),
+                attname='logo.png',
+                disposition='inline',
+                content_id='logo-1@example'
+            )
+            attachments = [
+                part for part in e.email.walk()
+                if part.get_filename() == 'logo.png'
+            ]
+            expect(len(attachments)).to(equal(1))
+            expect(attachments[0].get('Content-Disposition')).to(
+                equal('inline; filename="logo.png"')
+            )
+            expect(attachments[0].get('Content-ID')).to(
+                equal('<logo-1@example>')
+            )
+            expect(attachments[0].get_content_type()).to(equal('image/png'))
+
         with it('must raise an exception adding an unexisting attachment'):
             def call_wrongly():
                 e = Email()
@@ -550,4 +572,3 @@ with description('Filename without accents'):
         expected_file_name_2 = u"hola.pdf"
         new_filename_2 = e.remove_accent(basename(original_filename_2))
         expect(new_filename_2).to(equal(expected_file_name_2))
-

--- a/spec/qreu_spec.py
+++ b/spec/qreu_spec.py
@@ -355,6 +355,9 @@ with description("Creating an Email"):
             expect(attachments[0].get('Content-ID')).to(
                 equal('<logo-1@example>')
             )
+            expect(attachments[0].get('Content-Transfer-Encoding')).to(
+                equal('base64')
+            )
             expect(attachments[0].get_content_type()).to(equal('image/png'))
 
         with it('must raise an exception adding an unexisting attachment'):


### PR DESCRIPTION
## Summary
- Add optional `disposition` and `content_id` parameters to `Email.add_attachment`.
- Preserve the default attachment behavior while allowing inline MIME parts with `Content-ID`.
- Build attachment MIME parts with the guessed maintype/subtype so image attachments are emitted as `image/*`.
- Leave package version unchanged; release automation handles version bumps from labels.

## Tests
- `/home/openclaw/.pyenv/versions/erp3/bin/python -m py_compile qreu/email.py spec/qreu_spec.py setup.py`
- `PYTHONPATH=. /home/openclaw/.pyenv/versions/erp3/bin/mamba spec/qreu_spec.py --format=progress`